### PR TITLE
[WIP] add subscribers/speech.cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ set(
   SUBSCRIBER_SRC
   src/subscribers/teleop.cpp
   src/subscribers/moveto.cpp
+  src/subscribers/speech.cpp
   )
 
 set(

--- a/src/naoqi_driver.cpp
+++ b/src/naoqi_driver.cpp
@@ -60,6 +60,7 @@
  */
 #include "subscribers/teleop.hpp"
 #include "subscribers/moveto.hpp"
+#include "subscribers/speech.hpp"
 
 
 /*
@@ -787,6 +788,7 @@ void Driver::registerDefaultSubscriber()
     return;
   registerSubscriber( boost::make_shared<naoqi::subscriber::TeleopSubscriber>("teleop", "/cmd_vel", "/joint_angles", sessionPtr_) );
   registerSubscriber( boost::make_shared<naoqi::subscriber::MovetoSubscriber>("moveto", "/move_base_simple/goal", sessionPtr_, tf2_buffer_) );
+  registerSubscriber( boost::make_shared<naoqi::subscriber::SpeechSubscriber>("speech", "/speech", sessionPtr_) );
 }
 
 void Driver::registerService( service::Service srv )

--- a/src/subscribers/speech.cpp
+++ b/src/subscribers/speech.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2015 Aldebaran
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+/*
+ * LOCAL includes
+ */
+#include "speech.hpp"
+
+
+namespace naoqi
+{
+namespace subscriber
+{
+
+SpeechSubscriber::SpeechSubscriber( const std::string& name, const std::string& speech_topic, const qi::SessionPtr& session ):
+  speech_topic_(speech_topic),
+  BaseSubscriber( name, speech_topic, session ),
+  p_tts_( session->service("ALTextToSpeech") )
+{}
+
+void SpeechSubscriber::reset( ros::NodeHandle& nh )
+{
+  sub_speech_ = nh.subscribe( speech_topic_, 10, &SpeechSubscriber::speech_callback, this );
+
+  is_initialized_ = true;
+}
+
+void SpeechSubscriber::speech_callback( const std_msgs::StringConstPtr& string_msg )
+{
+  p_tts_.async<void>("say", string_msg->data);
+}
+
+} //publisher
+} // naoqi

--- a/src/subscribers/speech.hpp
+++ b/src/subscribers/speech.hpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2015 Aldebaran
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+
+#ifndef SPEECH_SUBSCRIBER_HPP
+#define SPEECH_SUBSCRIBER_HPP
+
+/*
+ * LOCAL includes
+ */
+#include "subscriber_base.hpp"
+
+/*
+ * ROS includes
+ */
+#include <ros/ros.h>
+#include <std_msgs/String.h>
+
+namespace naoqi
+{
+namespace subscriber
+{
+
+class SpeechSubscriber: public BaseSubscriber<SpeechSubscriber>
+{
+public:
+  SpeechSubscriber( const std::string& name, const std::string& speech_topic, const qi::SessionPtr& session );
+  ~SpeechSubscriber(){}
+
+  void reset( ros::NodeHandle& nh );
+  void speech_callback( const std_msgs::StringConstPtr& speech_msg );
+
+private:
+
+  std::string speech_topic_;
+
+  qi::AnyObject p_tts_;
+  ros::Subscriber sub_speech_;
+
+
+
+}; // class Speech
+
+} // subscriber
+}// naoqi
+#endif


### PR DESCRIPTION
This is an attempt to re-enable text-to-speech and speech recognition feature, which exists in old naoqi bridge (
https://github.com/ros-naoqi/nao_robot/blob/d88b154d91e785ed7071efb0d7f00c0096cee28e/nao_apps/nodes/nao_speech.py)

This PR only support tts feature (configuration (https://github.com/ros-naoqi/nao_robot/blob/d88b154d91e785ed7071efb0d7f00c0096cee28e/nao_apps/nodes/nao_speech.py#L256) are not included )
Since I'm very new to naoqi_driver package and just want to confirm that I'm on the right track.