### PR TITLE
prevent calling ros::init without name; use node_name command option instead of namespace

### DIFF
--- a/launch/naoqi_driver.launch
+++ b/launch/naoqi_driver.launch
@@ -3,7 +3,8 @@
   <arg name="nao_ip"            default="$(optenv NAO_IP)" />
   <arg name="roscore_ip"        default="127.0.0.1" />
   <arg name="network_interface" default="eth0" />
+  <arg name="node_name"         default="naoqi_driver" />
 
-  <node pkg="naoqi_driver" type="naoqi_driver_node" name="naoqi_driver" required="true" args="--qi-url=tcp://$(arg nao_ip):9559 --roscore_ip=$(arg roscore_ip) --network_interface=$(arg network_interface)" output="screen" />
+  <node pkg="naoqi_driver" type="naoqi_driver_node" name="$(arg node_name)" required="true" args="--qi-url=tcp://$(arg nao_ip):9559 --roscore_ip=$(arg roscore_ip) --network_interface=$(arg network_interface)" output="screen" />
 
 </launch>

--- a/src/external_registration.cpp
+++ b/src/external_registration.cpp
@@ -25,6 +25,15 @@
 #include "naoqi_env.hpp"
 #include "helpers/driver_helpers.hpp"
 
+std::pair<std::string, std::string> ros_node_name_parser(const std::string& o) {
+  if(o.find("__name:=") == 0) {
+    return std::make_pair(std::string("node_name"), o.substr(std::string("__name:=").size()));
+  } else {
+    return std::make_pair(std::string(), std::string());
+  }
+}
+
+
 int main(int argc, char** argv)
 {
   /* adjust the SDK prefix in case you compiled via catkin*/
@@ -37,17 +46,20 @@ int main(int argc, char** argv)
   ros::removeROSArgs( argc, argv, args_out );
 
   namespace po = boost::program_options;
-  po::options_description desc("Options");
+  po::options_description desc("Options"), all_desc("Options");
   desc.add_options()
     ("help,h", "print help message")
     ("roscore_ip,r", po::value<std::string>(), "set the ip of the roscore to use")
-    ("network_interface,i", po::value<std::string>()->default_value("eth0"),  "set the network interface over which to connect")
-    ("namespace,n", po::value<std::string>()->default_value(""), "set an explicit namespace in case ROS namespace variables cannot be used");
+    ("network_interface,i", po::value<std::string>()->default_value("eth0"),  "set the network interface over which to connect");
+
+  all_desc.add_options()
+    ("node_name,n", po::value<std::string>()->default_value("naoqi_driver"), "this node name");
+  all_desc.add(desc);
 
   po::variables_map vm;
   try
   {
-    po::store( po::parse_command_line(argc, argv, desc), vm );
+    po::store( po::command_line_parser(argc, argv).options(all_desc).extra_parser(ros_node_name_parser).run(), vm );
   }
   catch (boost::program_options::invalid_command_line_syntax& e)
   {
@@ -69,7 +81,7 @@ int main(int argc, char** argv)
 
   // everything's correctly parsed - let's start the app!
   app.start();
-  boost::shared_ptr<naoqi::Driver> bs = qi::import("naoqi_driver_module").call<qi::Object<naoqi::Driver> >("ROS-Driver", app.session(), vm["namespace"].as<std::string>()).asSharedPtr();
+  boost::shared_ptr<naoqi::Driver> bs = qi::import("naoqi_driver_module").call<qi::Object<naoqi::Driver> >("ROS-Driver", app.session(), vm["node_name"].as<std::string>()).asSharedPtr();
 
   app.session()->registerService("ROS-Driver", bs);
 

--- a/src/ros_env.hpp
+++ b/src/ros_env.hpp
@@ -88,8 +88,13 @@ static void setMasterURI( const std::string& uri, const std::string& network_int
   std::map< std::string, std::string > remap;
   remap["__master"] = uri;
   remap["__ip"] = ::naoqi::ros_env::getROSIP(network_interface);
+  std::string ros_node_name = ::naoqi::ros_env::getPrefix();
+  if (ros_node_name.empty()) {
+    std::cerr << "node_name can not be empty!!! please execute this node with `rosrun`/`roslaunch` or specify ROS node_name with --node_name=<name>" << std::endl;
+    exit(-1);
+  }
   // init ros without a sigint-handler in order to shutdown correctly by naoqi
-  ros::init( remap, ::naoqi::ros_env::getPrefix(), ros::init_options::NoSigintHandler );
+  ros::init( remap, ros_node_name, ros::init_options::NoSigintHandler );
   // to prevent shutdown based on no existing nodehandle
   ros::start();
 


### PR DESCRIPTION
Currently launching `naoqi_driver_node` without `--namespace` option causes mis-registering node name to ros master.

e.g. when launching by `roslaunch pepper_bringup pepper_full.launch` (`ros_naoqi_driver` is executed without `--namespace` option and under `ns="pepper_robot"`), the node name of `ros_naoqi_driver` is shown as `//pepper_robot` and ROS master cannot resolve address of this illegal ros node name.

```bash
$ rostopic info /cmd_vel
Type: geometry_msgs/Twist

Publishers: 
 * /teleop_twist_joy (http://133.11.216.136:44116/)
 * /pepper_1444291883382908575 (http://133.11.216.136:54125/) (Note: This is from pepper-interface.l)

Subscribers: 
 * //pepper_robot (unknown address //pepper_robot)  # this is invalid for ROS
```

Looking more deeply, I found that the value of command line option `--namespace`(https://github.com/ros-naoqi/naoqi_driver/blob/master/src/external_registration.cpp#L45) is passed to `ros::init` (https://github.com/ros-naoqi/naoqi_driver/blob/master/src/ros_env.hpp#L92) whose name must NOT be empty, so I added exception handler.
Also I'd like to point out that argument name `--namespace` is inappropriate and it is better to rename it to `--node_name` because the value of this option is passed to `ros::init`.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ros-naoqi/naoqi_driver/44)
<!-- Reviewable:end -->
