### PR TITLE
add photo capture feature

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ set(
   SUBSCRIBER_SRC
   src/subscribers/teleop.cpp
   src/subscribers/moveto.cpp
+  src/subscribers/photocapture.cpp
   )
 
 set(

--- a/src/naoqi_driver.cpp
+++ b/src/naoqi_driver.cpp
@@ -60,7 +60,7 @@
  */
 #include "subscribers/teleop.hpp"
 #include "subscribers/moveto.hpp"
-
+#include "subscribers/photocapture.hpp"
 
 /*
  * SERVICES
@@ -787,6 +787,7 @@ void Driver::registerDefaultSubscriber()
     return;
   registerSubscriber( boost::make_shared<naoqi::subscriber::TeleopSubscriber>("teleop", "/cmd_vel", "/joint_angles", sessionPtr_) );
   registerSubscriber( boost::make_shared<naoqi::subscriber::MovetoSubscriber>("moveto", "/move_base_simple/goal", sessionPtr_, tf2_buffer_) );
+  registerSubscriber( boost::make_shared<naoqi::subscriber::PhotoCaptureSubscriber>("photocapture", "/photo_capture", sessionPtr_));
 }
 
 void Driver::registerService( service::Service srv )

--- a/src/subscribers/photocapture.cpp
+++ b/src/subscribers/photocapture.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2015 Aldebaran
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/*
+ * LOCAL includes
+ */
+#include "photocapture.hpp"
+
+
+namespace naoqi
+{
+namespace subscriber
+{
+
+  PhotoCaptureSubscriber::PhotoCaptureSubscriber( const std::string& name, const std::string& photocapture_topic, const qi::SessionPtr& session):
+    photocapture_topic_(photocapture_topic),
+    BaseSubscriber( name, photocapture_topic, session ),
+    p_photocapture_( session->service("ALPhotoCapture") )
+  {}
+
+  void PhotoCaptureSubscriber::reset( ros::NodeHandle& nh )
+  {
+    sub_photocapture_ = nh.subscribe( photocapture_topic_, 10, &PhotoCaptureSubscriber::callback, this );
+    is_initialized_ = true;
+  }
+  void PhotoCaptureSubscriber::callback( const std_msgs::StringConstPtr& string_msg )
+  {
+    p_photocapture_.async<void>("setResolution", 2);
+    p_photocapture_.async<void>("setPictureFormat", "jpg");
+    p_photocapture_.async<void>("takePicture", "/home/nao/recordings/cameras/", string_msg->data);
+    std::cout << "photo name: "<<string_msg->data <<".jpg saved in /home/nao/recordings/cameras/"<< std::endl;  
+  }
+
+} //subscriber
+} // naoqi

--- a/src/subscribers/photocapture.hpp
+++ b/src/subscribers/photocapture.hpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2015 Aldebaran
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+
+#ifndef PHOTOCAPTURE_SUBSCRIBER_HPP
+#define PHOTOCAPTURE_SUBSCRIBER_HPP
+
+/*
+ * LOCAL includes
+ */
+#include "subscriber_base.hpp"
+
+/*
+ * ROS includes
+ */
+#include <ros/ros.h>
+#include <std_msgs/String.h>
+
+namespace naoqi
+{
+namespace subscriber
+{
+
+  class PhotoCaptureSubscriber: public BaseSubscriber<PhotoCaptureSubscriber>
+  {
+  public:
+    PhotoCaptureSubscriber( const std::string& name, const std::string& photocapture_topic, const qi::SessionPtr& session );
+    ~PhotoCaptureSubscriber(){}
+
+    void reset( ros::NodeHandle& nh );
+    void callback( const std_msgs::StringConstPtr& string_msg );
+
+  private:
+
+    std::string photocapture_topic_;
+
+    qi::AnyObject p_photocapture_;
+    ros::Subscriber sub_photocapture_;
+
+
+
+  }; // class PhotoCapture
+
+} // subscriber
+}// naoqi
+#endif


### PR DESCRIPTION
Following [WIP] add subscribers/speech.cpp #43, I added to photo capture feature. I checked this with Pepper who has NAOqi 2.3 version, PC which has ROS indigo. It requires  prevent calling ros::init without name; use node_name command option instead of namespace #44 and  [pepper_bringup/launch/pepper_full.launch] use node_name argument instead of namespace # 11.

If there is any problem, please let me know.  
