### PR TITLE
call startPublishing instaed of set true to publish_enabled_

### DIFF
--- a/src/naoqi_driver.cpp
+++ b/src/naoqi_driver.cpp
@@ -888,7 +888,7 @@ void Driver::setMasterURINet( const std::string& uri, const std::string& network
     }
   }
   // Start publishing again
-  publish_enabled_ = true;
+  startPublishing();
 
   if ( !keep_looping )
   {


### PR DESCRIPTION
Hi

I ran into trouble that the naoqi_driver does not pusboish /audio message.

It seems that isPublishing_ described here is false.
```
    if ( isPublishing_ && publisher_->isSubscribed() )

```
(https://github.com/ros-naoqi/naoqi_driver/blob/master/src/event/audio.cpp#L180)

This should be trune on 
```
    if (publish_enabled_) {
      event_map_.find("audio")->second.isPublishing(true);
    }
```
at https://github.com/ros-naoqi/naoqi_driver/blob/master/src/naoqi_driver.cpp#L757, but
when we call this function (`void Driver::registerDefaultConverter()`), `publish_enabled_` is set to false, 
and that is set to true at 
```
  // Start publishing again
  publish_enabled_ = true;
```
https://github.com/ros-naoqi/naoqi_driver/blob/master/src/naoqi_driver.cpp#L890

I'm not confiden on this patch, but I think we need to set isPublishig_ in audio.cpp to true at somewhere.