### PR TITLE
add bumper publisher

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ project(naoqi_driver)
 set(
   CONVERTERS_SRC
   src/converters/audio.cpp
+  src/converters/bumper.cpp
   src/converters/camera.cpp
   src/converters/diagnostics.cpp
   src/converters/imu.cpp

--- a/src/converters/bumper.cpp
+++ b/src/converters/bumper.cpp
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2015 Aldebaran
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+/*
+* LOCAL includes
+*/
+#include "bumper.hpp"
+#include "../tools/from_any_value.hpp"
+
+/*
+* ROS includes
+*/
+//#include <tf/transform_datatypes.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+
+/*
+* BOOST includes
+*/
+#include <boost/foreach.hpp>
+#define for_each BOOST_FOREACH
+
+namespace naoqi
+{
+namespace converter {
+
+
+  BumperConverter::BumperConverter(const std::string& name, const float& frequency, const qi::SessionPtr& session):
+    BaseConverter(name, frequency, session),
+    p_touch_( session->service("ALTouch") )
+  {
+  }
+
+  BumperConverter::~BumperConverter()
+  {
+  }
+
+  void BumperConverter::reset()
+  {
+
+  }
+
+  void BumperConverter::registerCallback( const message_actions::MessageAction action, Callback_t cb )
+  {
+    callbacks_[action] = cb;
+  }
+
+  void BumperConverter::callAll(const std::vector<message_actions::MessageAction>& actions)
+  {
+    // Get inertial data
+    std::vector<std::pair<std::string, bool> > values;
+    try {
+      qi::AnyValue anyvalues = p_touch_.call<qi::AnyValue>("getStatus");
+      tools::fromAnyValueToStringBoolPairVector(anyvalues, values);
+    } catch (const std::exception& e) {
+      std::cerr << "Exception caught in BumperConverter: " << e.what() << std::endl;
+      return;
+    }
+
+    int i = 0;
+    for (std::vector<std::pair<std::string, bool> >::const_iterator it=values.begin();
+         it!=values.end(); it++, i++)
+    {
+      std::string name = it->first;
+      bool state = it->second;
+      if ( name == "Bumper/FrontLeft" ) {
+        msg_bumper_.bumper = naoqi_bridge_msgs::Bumper::left;
+        msg_bumper_.state = state?(naoqi_bridge_msgs::Bumper::statePressed):(naoqi_bridge_msgs::Bumper::stateReleased);
+      } else if ( name == "Bumper/FrontLeft" ) {
+        msg_bumper_.bumper = naoqi_bridge_msgs::Bumper::right;
+        msg_bumper_.state = state?(naoqi_bridge_msgs::Bumper::statePressed):(naoqi_bridge_msgs::Bumper::stateReleased);
+      }
+    }
+
+    for_each( message_actions::MessageAction action, actions )
+    {
+      callbacks_[action]( msg_bumper_ );
+    }
+  }
+
+}
+
+}

--- a/src/converters/bumper.hpp
+++ b/src/converters/bumper.hpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2015 Aldebaran
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef BUMPER_CONVERTER_HPP
+#define BUMPER_CONVERTER_HPP
+
+/*
+* LOCAL includes
+*/
+#include "converter_base.hpp"
+#include <naoqi_driver/message_actions.h>
+
+/*
+* ROS includes
+*/
+#include <naoqi_bridge_msgs/Bumper.h>
+
+namespace naoqi
+{
+namespace converter {
+
+class BumperConverter : public BaseConverter<BumperConverter>
+{
+
+  typedef boost::function<void(naoqi_bridge_msgs::Bumper&) > Callback_t;
+
+public:
+  BumperConverter(const std::string& name, const float& frequency, const qi::SessionPtr& session);
+
+  ~BumperConverter();
+
+  virtual void reset();
+
+  void registerCallback( const message_actions::MessageAction action, Callback_t cb );
+
+  virtual void callAll(const std::vector<message_actions::MessageAction>& actions);
+
+private:
+  /** Touch (Proxy) configurations */
+  qi::AnyObject p_touch_;
+
+  /** Pre-filled messges that are sent */
+  naoqi_bridge_msgs::Bumper msg_bumper_;
+
+  /** Registered Callbacks **/
+  std::map<message_actions::MessageAction, Callback_t> callbacks_;
+};
+
+}
+
+}
+
+#endif // BUMPER_CONVERTER_HPP

--- a/src/naoqi_driver.cpp
+++ b/src/naoqi_driver.cpp
@@ -25,6 +25,7 @@
  * CONVERTERS
  */
 #include "converters/audio.hpp"
+#include "converters/bumper.hpp"
 #include "converters/camera.hpp"
 #include "converters/diagnostics.hpp"
 #include "converters/imu.hpp"
@@ -574,6 +575,8 @@ void Driver::registerDefaultConverter()
   bool sonar_enabled                  = boot_config_.get( "converters.sonar.enabled", true);
   size_t sonar_frequency              = boot_config_.get( "converters.sonar.frequency", 10);
 
+  bool bumper_enabled                 = boot_config_.get( "converters.bumper.enabled", true);
+  size_t bumper_frequency             = boot_config_.get( "converters.bumper.frequency", 10);
   /*
    * The info converter will be called once after it was added to the priority queue. Once it is its turn to be called, its
    * callAll method will be triggered (because InfoPublisher is considered to always have subscribers, isSubscribed always
@@ -757,6 +760,19 @@ void Driver::registerDefaultConverter()
       event_map_.find("audio")->second.isPublishing(true);
     }
   }
+
+  /** BUMPER **/
+  if ( bumper_enabled )
+  {
+    boost::shared_ptr<publisher::BasicPublisher<naoqi_bridge_msgs::Bumper> > bmpp = boost::make_shared<publisher::BasicPublisher<naoqi_bridge_msgs::Bumper> >( "bumper" );
+    //boost::shared_ptr<recorder::BasicRecorder<naoqi_bridge_msgs::Bumper> > bmpr = boost::make_shared<recorder::BasicRecorder<naoqi_bridge_msgs::Bumper> >( "bumper" );
+    boost::shared_ptr<converter::BumperConverter> bmpc = boost::make_shared<converter::BumperConverter>( "bumper", bumper_frequency, sessionPtr_);
+    bmpc->registerCallback( message_actions::PUBLISH, boost::bind(&publisher::BasicPublisher<naoqi_bridge_msgs::Bumper>::publish, bmpp, _1) );
+    //bmpc->registerCallback( message_actions::RECORD, boost::bind(&recorder::BasicRecorder<naoqi_bridge_msgs::Bumper>::write, bmpr, _1) );
+    //bmpc->registerCallback( message_actions::LOG, boost::bind(&recorder::BasicRecorder<naoqi_bridge_msgs::Bumper>::bufferize, bmpr, _1) );
+    registerPublisher( bmpc, bmpp );
+  }
+
 }
 
 // public interface here

--- a/src/tools/from_any_value.cpp
+++ b/src/tools/from_any_value.cpp
@@ -200,6 +200,24 @@ std::vector<float> fromAnyValueToFloatVector(qi::AnyValue& value, std::vector<fl
   return result;
 }
 
+std::vector<int> fromAnyValueToIntegerVector(qi::AnyValue& value, std::vector<int>& result){
+  qi::AnyReferenceVector anyrefs = value.asListValuePtr();
+
+  for(int i=0; i<anyrefs.size();i++)
+  {
+    try
+    {
+      result.push_back(anyrefs[i].content().toInt());
+    }
+    catch(std::runtime_error& e)
+    {
+      result.push_back(-1);
+      std::cout << e.what() << "=> set to -1" << std::endl;
+    }
+  }
+  return result;
+}
+
 std::vector<std::string> fromAnyValueToStringVector(qi::AnyValue& value, std::vector<std::string>& result){
   qi::AnyReferenceVector anyrefs = value.asListValuePtr();
 
@@ -215,6 +233,25 @@ std::vector<std::string> fromAnyValueToStringVector(qi::AnyValue& value, std::ve
       std::cout << e.what() << " => set to 'Not available'" << std::endl;
     }
   }
+  return result;
+}
+
+std::vector<std::pair<std::string, bool> > fromAnyValueToStringBoolPairVector(qi::AnyValue& value, std::vector<std::pair<std::string, bool> >& result){
+  qi::AnyReferenceVector anyrefs1 = value.asListValuePtr();
+
+  for(int i=0; i<anyrefs1.size();i++)
+  {
+    try
+    {
+      qi::AnyReferenceVector anyrefs2 = anyrefs1[i].asTupleValuePtr();
+      result.push_back(std::pair<std::string, bool>(anyrefs[i].content()[0].toString(), anyrefs[i].content()[1].toInt()==1));
+    }
+    catch(std::runtime_error& e)
+    {
+      std::cout << e.what() << std::endl;
+    }
+  }
+  std::cerr << std::endl;
   return result;
 }
 

--- a/src/tools/from_any_value.hpp
+++ b/src/tools/from_any_value.hpp
@@ -38,6 +38,10 @@ std::vector<std::string> fromAnyValueToStringVector(qi::AnyValue& value, std::ve
 
 std::vector<float> fromAnyValueToFloatVector(qi::AnyValue& value, std::vector<float>& result);
 
+std::vector<int> fromAnyValueToIntegerVector(qi::AnyValue& value, std::vector<int>& result);
+
+std::vector<std::pair<std::string, bool> > fromAnyValueToStringBoolPairVector(qi::AnyValue& value, std::vector<std::pair<std::string, bool> >& result);
+
 }
 
 }


### PR DESCRIPTION
Hi,

I'm start working on bumper/touch sensor publisher (https://github.com/ros-naoqi/naoqi_driver/issues/32), but got into trouble.
This PR will get sensor data using `ALTouch -> getStatus` (http://doc.aldebaran.com/2-1/naoqi/sensors/altouch-api.html#ALTouchProxy::getStatus) and 
this seems working well becase we can get list of sensors as follow if we write obtaind list (from manual it should be a vector of pairs [name, bool] )

```
Head 0 LArm 0 Leg 0 RArm 0 LHand 0 RHand 0 Bumper/Back 0 Bumper/FrontLeft 0 Bumper/FrontRight 0 Head/Touch/Front 0 Head/Touch/Middle 0 Head/Touch/Rear 0 LHand/Touch/Back 0 RHand/Touch/Back 0 Base 0 
```
but `bool` value does not change. I think I did something wrong around 
https://github.com/k-okada/naoqi_driver/commit/dc6bdfc3c52c00db69929963db5ded09e03eb3bb#diff-48187f35d5fe15f7b274add5d287a20fR247
but could not get solution so far. Any help are welcome.

During working on this issue, I have several questions.

1) because ALTouch is designed to use as event based callback function, is there way to implemnet this in naoqi_driver? I look into event/audio.cpp but it seems something differnt.

2) As far as I understand correctly, Publisher is desinged to publish one message, In my implementation, I used `getStatus` in `callAll` function, but previous https://github.com/ros-naoqi/nao_robot/blob/master/nao_apps/nodes/nao_tactile.py will publish two message for each left and right bumper event. How can I implement them.

3) Moreover, if we want to keep backword compaitbility, nao_tactile publishes to `bumper` for bumper data and `tactile_touch` for tactile sensor. Is it possible to write such Publishe in current framework?

Thanks in advance.