### PR TITLE
add touch event and converters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ project(naoqi_driver)
 set(
   CONVERTERS_SRC
   src/converters/audio.cpp
+  src/converters/touch.cpp
   src/converters/camera.cpp
   src/converters/diagnostics.cpp
   src/converters/imu.cpp
@@ -62,6 +63,7 @@ set(
   src/event/basic.hxx
   src/event/basic.hpp
   src/event/audio.cpp
+  src/event/touch.cpp
   )
 
 # use catkin if qibuild is not found

--- a/src/converters/touch.cpp
+++ b/src/converters/touch.cpp
@@ -30,24 +30,29 @@ namespace naoqi{
 
 namespace converter{
 
-BumperEventConverter::BumperEventConverter(const std::string& name, const float& frequency, const qi::SessionPtr& session)
-    : BaseConverter(name, frequency, session)
+template <class T>
+TouchEventConverter<T>::TouchEventConverter(const std::string& name, const float& frequency, const qi::SessionPtr& session)
+  : BaseConverter<TouchEventConverter<T> >(name, frequency, session)
 {
 }
 
-BumperEventConverter::~BumperEventConverter() {
+template <class T>
+TouchEventConverter<T>::~TouchEventConverter() {
 }
 
-void BumperEventConverter::reset()
+template <class T>
+void TouchEventConverter<T>::reset()
 {
 }
 
-void BumperEventConverter::registerCallback( const message_actions::MessageAction action, Callback_t cb )
+template <class T>
+void TouchEventConverter<T>::registerCallback( const message_actions::MessageAction action, Callback_t cb )
 {
   callbacks_[action] = cb;
 }
 
-void BumperEventConverter::callAll(const std::vector<message_actions::MessageAction>& actions, naoqi_bridge_msgs::Bumper& msg)
+template <class T>
+void TouchEventConverter<T>::callAll(const std::vector<message_actions::MessageAction>& actions, T& msg)
 {
   msg_ = msg;
   for_each( message_actions::MessageAction action, actions )
@@ -56,34 +61,9 @@ void BumperEventConverter::callAll(const std::vector<message_actions::MessageAct
   }
 }
 
-////
-
-TactileTouchEventConverter::TactileTouchEventConverter(const std::string& name, const float& frequency, const qi::SessionPtr& session)
-    : BaseConverter(name, frequency, session)
-{
-}
-
-TactileTouchEventConverter::~TactileTouchEventConverter() {
-}
-
-void TactileTouchEventConverter::reset()
-{
-}
-
-void TactileTouchEventConverter::registerCallback( const message_actions::MessageAction action, Callback_t cb )
-{
-  callbacks_[action] = cb;
-}
-
-void TactileTouchEventConverter::callAll(const std::vector<message_actions::MessageAction>& actions, naoqi_bridge_msgs::TactileTouch& msg)
-{
-  msg_ = msg;
-  for_each( message_actions::MessageAction action, actions )
-  {
-    callbacks_[action](msg_);
-  }
-}
-
+// http://stackoverflow.com/questions/8752837/undefined-reference-to-template-class-constructor
+template class TouchEventConverter<naoqi_bridge_msgs::Bumper>;
+template class TouchEventConverter<naoqi_bridge_msgs::TactileTouch>;
 }
 
 }

--- a/src/converters/touch.cpp
+++ b/src/converters/touch.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2015 Aldebaran
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+/*
+* LOCAL includes
+*/
+#include "touch.hpp"
+
+/*
+* BOOST includes
+*/
+#include <boost/foreach.hpp>
+#define for_each BOOST_FOREACH
+
+namespace naoqi{
+
+namespace converter{
+
+BumperEventConverter::BumperEventConverter(const std::string& name, const float& frequency, const qi::SessionPtr& session)
+    : BaseConverter(name, frequency, session)
+{
+}
+
+BumperEventConverter::~BumperEventConverter() {
+}
+
+void BumperEventConverter::reset()
+{
+}
+
+void BumperEventConverter::registerCallback( const message_actions::MessageAction action, Callback_t cb )
+{
+  callbacks_[action] = cb;
+}
+
+void BumperEventConverter::callAll(const std::vector<message_actions::MessageAction>& actions, naoqi_bridge_msgs::Bumper& msg)
+{
+  msg_ = msg;
+  for_each( message_actions::MessageAction action, actions )
+  {
+    callbacks_[action](msg_);
+  }
+}
+
+////
+
+TactileTouchEventConverter::TactileTouchEventConverter(const std::string& name, const float& frequency, const qi::SessionPtr& session)
+    : BaseConverter(name, frequency, session)
+{
+}
+
+TactileTouchEventConverter::~TactileTouchEventConverter() {
+}
+
+void TactileTouchEventConverter::reset()
+{
+}
+
+void TactileTouchEventConverter::registerCallback( const message_actions::MessageAction action, Callback_t cb )
+{
+  callbacks_[action] = cb;
+}
+
+void TactileTouchEventConverter::callAll(const std::vector<message_actions::MessageAction>& actions, naoqi_bridge_msgs::TactileTouch& msg)
+{
+  msg_ = msg;
+  for_each( message_actions::MessageAction action, actions )
+  {
+    callbacks_[action](msg_);
+  }
+}
+
+}
+
+}

--- a/src/converters/touch.hpp
+++ b/src/converters/touch.hpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2015 Aldebaran
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef TOUCH_EVENT_CONVERTER_HPP
+#define TOUCH_EVENT_CONVERTER_HPP
+
+/*
+* LOCAL includes
+*/
+#include "converter_base.hpp"
+#include <naoqi_driver/message_actions.h>
+
+/*
+* ROS includes
+*/
+#include <naoqi_bridge_msgs/Bumper.h>
+#include <naoqi_bridge_msgs/TactileTouch.h>
+
+/*
+* ALDEBARAN includes
+*/
+#include <qi/anymodule.hpp>
+
+namespace naoqi{
+
+namespace converter{
+
+class BumperEventConverter : public BaseConverter<BumperEventConverter>
+{
+
+  typedef boost::function<void(naoqi_bridge_msgs::Bumper&) > Callback_t;
+
+public:
+  BumperEventConverter(const std::string& name, const float& frequency, const qi::SessionPtr& session);
+
+  ~BumperEventConverter();
+
+  virtual void reset();
+
+  void registerCallback( const message_actions::MessageAction action, Callback_t cb );
+
+  void callAll(const std::vector<message_actions::MessageAction>& actions, naoqi_bridge_msgs::Bumper& msg);
+
+private:
+  /** Registered Callbacks **/
+  std::map<message_actions::MessageAction, Callback_t> callbacks_;
+  naoqi_bridge_msgs::Bumper msg_;
+};
+
+class TactileTouchEventConverter : public BaseConverter<TactileTouchEventConverter>
+{
+
+  typedef boost::function<void(naoqi_bridge_msgs::TactileTouch&) > Callback_t;
+
+public:
+  TactileTouchEventConverter(const std::string& name, const float& frequency, const qi::SessionPtr& session);
+
+  ~TactileTouchEventConverter();
+
+  virtual void reset();
+
+  void registerCallback( const message_actions::MessageAction action, Callback_t cb );
+
+  void callAll(const std::vector<message_actions::MessageAction>& actions, naoqi_bridge_msgs::TactileTouch& msg);
+
+private:
+  /** Registered Callbacks **/
+  std::map<message_actions::MessageAction, Callback_t> callbacks_;
+  naoqi_bridge_msgs::TactileTouch msg_;
+};
+}
+
+}
+
+#endif // TOUCH_CONVERTER_HPP

--- a/src/converters/touch.hpp
+++ b/src/converters/touch.hpp
@@ -39,49 +39,29 @@ namespace naoqi{
 
 namespace converter{
 
-class BumperEventConverter : public BaseConverter<BumperEventConverter>
+template <class T>
+class TouchEventConverter : public BaseConverter<TouchEventConverter<T> >
 {
 
-  typedef boost::function<void(naoqi_bridge_msgs::Bumper&) > Callback_t;
+  typedef boost::function<void(T&) > Callback_t;
 
 public:
-  BumperEventConverter(const std::string& name, const float& frequency, const qi::SessionPtr& session);
+  TouchEventConverter(const std::string& name, const float& frequency, const qi::SessionPtr& session);
 
-  ~BumperEventConverter();
+  ~TouchEventConverter();
 
   virtual void reset();
 
   void registerCallback( const message_actions::MessageAction action, Callback_t cb );
 
-  void callAll(const std::vector<message_actions::MessageAction>& actions, naoqi_bridge_msgs::Bumper& msg);
+  void callAll(const std::vector<message_actions::MessageAction>& actions, T& msg);
 
 private:
   /** Registered Callbacks **/
   std::map<message_actions::MessageAction, Callback_t> callbacks_;
-  naoqi_bridge_msgs::Bumper msg_;
+  T msg_;
 };
 
-class TactileTouchEventConverter : public BaseConverter<TactileTouchEventConverter>
-{
-
-  typedef boost::function<void(naoqi_bridge_msgs::TactileTouch&) > Callback_t;
-
-public:
-  TactileTouchEventConverter(const std::string& name, const float& frequency, const qi::SessionPtr& session);
-
-  ~TactileTouchEventConverter();
-
-  virtual void reset();
-
-  void registerCallback( const message_actions::MessageAction action, Callback_t cb );
-
-  void callAll(const std::vector<message_actions::MessageAction>& actions, naoqi_bridge_msgs::TactileTouch& msg);
-
-private:
-  /** Registered Callbacks **/
-  std::map<message_actions::MessageAction, Callback_t> callbacks_;
-  naoqi_bridge_msgs::TactileTouch msg_;
-};
 }
 
 }

--- a/src/event/touch.cpp
+++ b/src/event/touch.cpp
@@ -48,7 +48,7 @@ BumperEventRegister::BumperEventRegister( const std::string& name, const std::ve
 {
   publisher_ = boost::make_shared<publisher::BasicPublisher<naoqi_bridge_msgs::Bumper> >( name );
   //recorder_ = boost::make_shared<recorder::BasicEventRecorder<naoqi_bridge_msgs::Bumper> >( name );
-  converter_ = boost::make_shared<converter::BumperEventConverter>( name, frequency, session );
+  converter_ = boost::make_shared<converter::TouchEventConverter<naoqi_bridge_msgs::Bumper> >( name, frequency, session );
 
   converter_->registerCallback( message_actions::PUBLISH, boost::bind(&publisher::BasicPublisher<naoqi_bridge_msgs::Bumper>::publish, publisher_, _1) );
   //converter_->registerCallback( message_actions::RECORD, boost::bind(&recorder::BasicEventRecorder<naoqi_bridge_msgs::Bumper>::write, recorder_, _1) );
@@ -206,7 +206,7 @@ TactileTouchEventRegister::TactileTouchEventRegister( const std::string& name, c
 {
   publisher_ = boost::make_shared<publisher::BasicPublisher<naoqi_bridge_msgs::TactileTouch> >( name );
   //recorder_ = boost::make_shared<recorder::BasicEventRecorder<naoqi_bridge_msgs::Bumper> >( name );
-  converter_ = boost::make_shared<converter::TactileTouchEventConverter>( name, frequency, session );
+  converter_ = boost::make_shared<converter::TouchEventConverter<naoqi_bridge_msgs::TactileTouch> >( name, frequency, session );
 
   converter_->registerCallback( message_actions::PUBLISH, boost::bind(&publisher::BasicPublisher<naoqi_bridge_msgs::TactileTouch>::publish, publisher_, _1) );
   //converter_->registerCallback( message_actions::RECORD, boost::bind(&recorder::BasicEventRecorder<naoqi_bridge_msgs::Bumper>::write, recorder_, _1) );

--- a/src/event/touch.cpp
+++ b/src/event/touch.cpp
@@ -1,0 +1,352 @@
+/*
+ * Copyright 2015 Aldebaran
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <iostream>
+#include <vector>
+
+#include <boost/make_shared.hpp>
+
+#include <ros/ros.h>
+
+#include <qi/anyobject.hpp>
+
+#include <naoqi_driver/recorder/globalrecorder.hpp>
+#include <naoqi_driver/message_actions.h>
+
+#include "touch.hpp"
+
+namespace naoqi
+{
+
+BumperEventRegister::BumperEventRegister()
+{
+}
+
+BumperEventRegister::BumperEventRegister( const std::string& name, const std::vector<std::string> keys, const float& frequency, const qi::SessionPtr& session )
+  : serviceId(0),
+    p_memory_( session->service("ALMemory")),
+    p_touch_( session->service("ALTouch")),
+    session_(session),
+    isStarted_(false),
+    isPublishing_(false),
+    isRecording_(false),
+    isDumping_(false)
+{
+  publisher_ = boost::make_shared<publisher::BasicPublisher<naoqi_bridge_msgs::Bumper> >( name );
+  //recorder_ = boost::make_shared<recorder::BasicEventRecorder<naoqi_bridge_msgs::Bumper> >( name );
+  converter_ = boost::make_shared<converter::BumperEventConverter>( name, frequency, session );
+
+  converter_->registerCallback( message_actions::PUBLISH, boost::bind(&publisher::BasicPublisher<naoqi_bridge_msgs::Bumper>::publish, publisher_, _1) );
+  //converter_->registerCallback( message_actions::RECORD, boost::bind(&recorder::BasicEventRecorder<naoqi_bridge_msgs::Bumper>::write, recorder_, _1) );
+  //converter_->registerCallback( message_actions::LOG, boost::bind(&recorder::BasicEventRecorder<naoqi_bridge_msgs::Bumper>::bufferize, recorder_, _1) );
+
+  keys_.resize(keys.size());
+  size_t i = 0;
+  for(std::vector<std::string>::const_iterator it = keys.begin(); it != keys.end(); ++it, ++i)
+    keys_[i] = *it;
+
+  name_ = name;
+}
+
+BumperEventRegister::~BumperEventRegister()
+{
+  stopProcess();
+}
+
+void BumperEventRegister::resetPublisher(ros::NodeHandle& nh)
+{
+  publisher_->reset(nh);
+}
+
+void BumperEventRegister::resetRecorder( boost::shared_ptr<naoqi::recorder::GlobalRecorder> gr )
+{
+  //recorder_->reset(gr, converter_->frequency());
+}
+
+void BumperEventRegister::startProcess()
+{
+  boost::mutex::scoped_lock start_lock(mutex_);
+  if (!isStarted_)
+  {
+    if(!serviceId)
+    {
+      serviceId = session_->registerService("ROS-Driver-Bumper", shared_from_this());
+      for(std::vector<std::string>::const_iterator it = keys_.begin(); it != keys_.end(); ++it)
+        p_memory_.call<void>("subscribeToEvent",it->c_str(), "ROS-Driver-Bumper", "touchCallback");
+      std::cout << "Bumper : Start" << std::endl;
+    }
+    isStarted_ = true;
+  }
+}
+
+void BumperEventRegister::stopProcess()
+{
+  boost::mutex::scoped_lock stop_lock(mutex_);
+  if (isStarted_)
+  {
+    if(serviceId){
+      p_touch_.call<void>("unsubscribeToEvent", "ROS-Driver-Bumper");
+      session_->unregisterService(serviceId);
+      serviceId = 0;
+    }
+    std::cout << "Bumper: Stop" << std::endl;
+    isStarted_ = false;
+  }
+}
+
+void BumperEventRegister::writeDump(const ros::Time& time)
+{
+  if (isStarted_)
+  {
+    //recorder_->writeDump(time);
+  }
+}
+
+void BumperEventRegister::setBufferDuration(float duration)
+{
+  //recorder_->setBufferDuration(duration);
+}
+
+void BumperEventRegister::isRecording(bool state)
+{
+  boost::mutex::scoped_lock rec_lock(mutex_);
+  isRecording_ = state;
+}
+
+void BumperEventRegister::isPublishing(bool state)
+{
+  boost::mutex::scoped_lock pub_lock(mutex_);
+  isPublishing_ = state;
+}
+
+void BumperEventRegister::isDumping(bool state)
+{
+  boost::mutex::scoped_lock dump_lock(mutex_);
+  isDumping_ = state;
+}
+
+void BumperEventRegister::registerCallback()
+{
+}
+
+void BumperEventRegister::unregisterCallback()
+{
+}
+
+void BumperEventRegister::touchCallback(std::string &key, qi::AnyValue &value, qi::AnyValue &message)
+{
+  naoqi_bridge_msgs::Bumper msg = naoqi_bridge_msgs::Bumper();
+  
+  bool state =  value.toFloat() > 0.5f;
+
+  std::cerr << key << " " << state << std::endl;
+  int i = 0;
+  for(std::vector<std::string>::const_iterator it = keys_.begin(); it != keys_.end(); ++it, ++i)
+  {
+    if ( key == it->c_str() ) {
+      msg.bumper = i;
+      msg.state = state?(naoqi_bridge_msgs::Bumper::statePressed):(naoqi_bridge_msgs::Bumper::stateReleased);
+    }
+  }    
+
+  isPublishing_ = true;
+  std::vector<message_actions::MessageAction> actions;
+  boost::mutex::scoped_lock callback_lock(mutex_);
+  if (isStarted_) {
+    // CHECK FOR PUBLISH
+    if ( isPublishing_ && publisher_->isSubscribed() )
+    {
+      actions.push_back(message_actions::PUBLISH);
+    }
+    // CHECK FOR RECORD
+    if ( isRecording_ )
+    {
+      //actions.push_back(message_actions::RECORD);
+    }
+    if ( !isDumping_ )
+    {
+      //actions.push_back(message_actions::LOG);
+    }
+    if (actions.size() >0)
+    {
+      converter_->callAll( actions, msg );
+    }
+  }
+}
+
+////
+
+TactileTouchEventRegister::TactileTouchEventRegister()
+{
+}
+
+TactileTouchEventRegister::TactileTouchEventRegister( const std::string& name, const std::vector<std::string> keys, const float& frequency, const qi::SessionPtr& session )
+  : serviceId(0),
+    p_memory_( session->service("ALMemory")),
+    p_touch_( session->service("ALTouch")),
+    session_(session),
+    isStarted_(false),
+    isPublishing_(false),
+    isRecording_(false),
+    isDumping_(false)
+{
+  publisher_ = boost::make_shared<publisher::BasicPublisher<naoqi_bridge_msgs::TactileTouch> >( name );
+  //recorder_ = boost::make_shared<recorder::BasicEventRecorder<naoqi_bridge_msgs::Bumper> >( name );
+  converter_ = boost::make_shared<converter::TactileTouchEventConverter>( name, frequency, session );
+
+  converter_->registerCallback( message_actions::PUBLISH, boost::bind(&publisher::BasicPublisher<naoqi_bridge_msgs::TactileTouch>::publish, publisher_, _1) );
+  //converter_->registerCallback( message_actions::RECORD, boost::bind(&recorder::BasicEventRecorder<naoqi_bridge_msgs::Bumper>::write, recorder_, _1) );
+  //converter_->registerCallback( message_actions::LOG, boost::bind(&recorder::BasicEventRecorder<naoqi_bridge_msgs::Bumper>::bufferize, recorder_, _1) );
+
+  keys_.resize(keys.size());
+  size_t i = 0;
+  for(std::vector<std::string>::const_iterator it = keys.begin(); it != keys.end(); ++it, ++i)
+    keys_[i] = *it;
+
+  name_ = name;
+}
+
+TactileTouchEventRegister::~TactileTouchEventRegister()
+{
+  stopProcess();
+}
+
+void TactileTouchEventRegister::resetPublisher(ros::NodeHandle& nh)
+{
+  publisher_->reset(nh);
+}
+
+void TactileTouchEventRegister::resetRecorder( boost::shared_ptr<naoqi::recorder::GlobalRecorder> gr )
+{
+  //recorder_->reset(gr, converter_->frequency());
+}
+
+void TactileTouchEventRegister::startProcess()
+{
+  boost::mutex::scoped_lock start_lock(mutex_);
+  if (!isStarted_)
+  {
+    if(!serviceId)
+    {
+      serviceId = session_->registerService("ROS-Driver-TactileTouch", shared_from_this());
+      for(std::vector<std::string>::const_iterator it = keys_.begin(); it != keys_.end(); ++it)
+        p_memory_.call<void>("subscribeToEvent",it->c_str(), "ROS-Driver-TactileTouch", "touchCallback");
+      std::cout << "TactileTouch : Start" << std::endl;
+    }
+    isStarted_ = true;
+  }
+}
+
+void TactileTouchEventRegister::stopProcess()
+{
+  boost::mutex::scoped_lock stop_lock(mutex_);
+  if (isStarted_)
+  {
+    if(serviceId){
+      p_touch_.call<void>("unsubscribeToEvent", "ROS-Driver-TactileTouch");
+      session_->unregisterService(serviceId);
+      serviceId = 0;
+    }
+    std::cout << "TactileTouch: Stop" << std::endl;
+    isStarted_ = false;
+  }
+}
+
+void TactileTouchEventRegister::writeDump(const ros::Time& time)
+{
+  if (isStarted_)
+  {
+    //recorder_->writeDump(time);
+  }
+}
+
+void TactileTouchEventRegister::setBufferDuration(float duration)
+{
+  //recorder_->setBufferDuration(duration);
+}
+
+void TactileTouchEventRegister::isRecording(bool state)
+{
+  boost::mutex::scoped_lock rec_lock(mutex_);
+  isRecording_ = state;
+}
+
+void TactileTouchEventRegister::isPublishing(bool state)
+{
+  boost::mutex::scoped_lock pub_lock(mutex_);
+  isPublishing_ = state;
+}
+
+void TactileTouchEventRegister::isDumping(bool state)
+{
+  boost::mutex::scoped_lock dump_lock(mutex_);
+  isDumping_ = state;
+}
+
+void TactileTouchEventRegister::registerCallback()
+{
+}
+
+void TactileTouchEventRegister::unregisterCallback()
+{
+}
+
+void TactileTouchEventRegister::touchCallback(std::string &key, qi::AnyValue &value, qi::AnyValue &message)
+{
+  naoqi_bridge_msgs::TactileTouch msg = naoqi_bridge_msgs::TactileTouch();
+  
+  bool state =  value.toFloat() > 0.5f;
+
+  std::cerr << key << " " << state << std::endl;
+  int i = 0;
+  for(std::vector<std::string>::const_iterator it = keys_.begin(); it != keys_.end(); ++it, ++i)
+  {
+    if ( key == it->c_str() ) {
+      msg.button = i;
+      msg.state = state?(naoqi_bridge_msgs::TactileTouch::statePressed):(naoqi_bridge_msgs::TactileTouch::stateReleased);
+    }
+  }    
+
+  isPublishing_ = true;
+  std::vector<message_actions::MessageAction> actions;
+  boost::mutex::scoped_lock callback_lock(mutex_);
+  if (isStarted_) {
+    // CHECK FOR PUBLISH
+    if ( isPublishing_ && publisher_->isSubscribed() )
+    {
+      actions.push_back(message_actions::PUBLISH);
+    }
+    // CHECK FOR RECORD
+    if ( isRecording_ )
+    {
+      //actions.push_back(message_actions::RECORD);
+    }
+    if ( !isDumping_ )
+    {
+      //actions.push_back(message_actions::LOG);
+    }
+    if (actions.size() >0)
+    {
+      converter_->callAll( actions, msg );
+    }
+  }
+}
+
+QI_REGISTER_OBJECT(BumperEventRegister, touchCallback)
+QI_REGISTER_OBJECT(TactileTouchEventRegister, touchCallback)
+
+}//namespace

--- a/src/event/touch.hpp
+++ b/src/event/touch.hpp
@@ -84,7 +84,7 @@ private:
   void onEvent();
 
 private:
-  boost::shared_ptr<converter::BumperEventConverter> converter_;
+  boost::shared_ptr<converter::TouchEventConverter<naoqi_bridge_msgs::Bumper> > converter_;
   boost::shared_ptr<publisher::BasicPublisher<naoqi_bridge_msgs::Bumper> > publisher_;
   //boost::shared_ptr<recorder::BasicEventRecorder<naoqi_bridge_msgs::Bumper> > recorder_;
 
@@ -138,7 +138,7 @@ private:
   void onEvent();
 
 private:
-  boost::shared_ptr<converter::TactileTouchEventConverter> converter_;
+  boost::shared_ptr<converter::TouchEventConverter<naoqi_bridge_msgs::TactileTouch> > converter_;
   boost::shared_ptr<publisher::BasicPublisher<naoqi_bridge_msgs::TactileTouch> > publisher_;
   //boost::shared_ptr<recorder::BasicEventRecorder<naoqi_bridge_msgs::TactileTouch> > recorder_;
 

--- a/src/event/touch.hpp
+++ b/src/event/touch.hpp
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2015 Aldebaran
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef TOUCH_EVENT_REGISTER_HPP
+#define TOUCH_EVENT_REGISTER_HPP
+
+#include <string>
+
+#include <boost/make_shared.hpp>
+#include <boost/shared_ptr.hpp>
+#include <boost/thread/mutex.hpp>
+#include <boost/enable_shared_from_this.hpp>
+
+#include <qi/session.hpp>
+
+#include <ros/ros.h>
+#include <naoqi_bridge_msgs/Bumper.h>
+#include <naoqi_bridge_msgs/TactileTouch.h>
+
+#include <naoqi_driver/tools.hpp>
+#include <naoqi_driver/recorder/globalrecorder.hpp>
+
+// Converter
+#include "../src/converters/touch.hpp"
+// Publisher
+#include "../src/publishers/basic.hpp"
+// Recorder
+#include "../recorder/basic_event.hpp"
+
+namespace naoqi
+{
+
+/**
+* @brief GlobalRecorder concept interface
+* @note this defines an private concept struct,
+* which each instance has to implement
+* @note a type erasure pattern in implemented here to avoid strict inheritance,
+* thus each possible publisher instance has to implement the virtual functions mentioned in the concept
+*/
+class BumperEventRegister: public boost::enable_shared_from_this<BumperEventRegister>
+{
+
+public:
+
+  /**
+  * @brief Constructor for recorder interface
+  */
+  BumperEventRegister();
+  BumperEventRegister(const std::string& name, const std::vector<std::string> keys, const float& frequency, const qi::SessionPtr& session );
+  ~BumperEventRegister();
+
+  void resetPublisher( ros::NodeHandle& nh );
+  void resetRecorder( boost::shared_ptr<naoqi::recorder::GlobalRecorder> gr );
+
+  void startProcess();
+  void stopProcess();
+
+  void writeDump(const ros::Time& time);
+  void setBufferDuration(float duration);
+
+  void isRecording(bool state);
+  void isPublishing(bool state);
+  void isDumping(bool state);
+
+  void touchCallback(std::string &key, qi::AnyValue &value, qi::AnyValue &message);
+
+private:
+  void registerCallback();
+  void unregisterCallback();
+  void onEvent();
+
+private:
+  boost::shared_ptr<converter::BumperEventConverter> converter_;
+  boost::shared_ptr<publisher::BasicPublisher<naoqi_bridge_msgs::Bumper> > publisher_;
+  //boost::shared_ptr<recorder::BasicEventRecorder<naoqi_bridge_msgs::Bumper> > recorder_;
+
+  qi::SessionPtr session_;
+  qi::AnyObject p_touch_;
+  qi::AnyObject p_memory_;
+  unsigned int serviceId;
+  std::vector<std::string> keys_;
+  std::string name_;
+
+  boost::mutex mutex_;
+
+  bool isStarted_;
+  bool isPublishing_;
+  bool isRecording_;
+  bool isDumping_;
+
+}; // class
+
+
+class TactileTouchEventRegister: public boost::enable_shared_from_this<TactileTouchEventRegister>
+{
+
+public:
+
+  /**
+  * @brief Constructor for recorder interface
+  */
+  TactileTouchEventRegister();
+  TactileTouchEventRegister(const std::string& name, const std::vector<std::string> keys, const float& frequency, const qi::SessionPtr& session );
+  ~TactileTouchEventRegister();
+
+  void resetPublisher( ros::NodeHandle& nh );
+  void resetRecorder( boost::shared_ptr<naoqi::recorder::GlobalRecorder> gr );
+
+  void startProcess();
+  void stopProcess();
+
+  void writeDump(const ros::Time& time);
+  void setBufferDuration(float duration);
+
+  void isRecording(bool state);
+  void isPublishing(bool state);
+  void isDumping(bool state);
+
+  void touchCallback(std::string &key, qi::AnyValue &value, qi::AnyValue &message);
+
+private:
+  void registerCallback();
+  void unregisterCallback();
+  void onEvent();
+
+private:
+  boost::shared_ptr<converter::TactileTouchEventConverter> converter_;
+  boost::shared_ptr<publisher::BasicPublisher<naoqi_bridge_msgs::TactileTouch> > publisher_;
+  //boost::shared_ptr<recorder::BasicEventRecorder<naoqi_bridge_msgs::TactileTouch> > recorder_;
+
+  qi::SessionPtr session_;
+  qi::AnyObject p_touch_;
+  qi::AnyObject p_memory_;
+  unsigned int serviceId;
+  std::vector<std::string> keys_;
+  std::string name_;
+
+  boost::mutex mutex_;
+
+  bool isStarted_;
+  bool isPublishing_;
+  bool isRecording_;
+  bool isDumping_;
+
+}; // class
+
+
+} //naoqi
+
+#endif

--- a/src/event/touch.hpp
+++ b/src/event/touch.hpp
@@ -51,7 +51,8 @@ namespace naoqi
 * @note a type erasure pattern in implemented here to avoid strict inheritance,
 * thus each possible publisher instance has to implement the virtual functions mentioned in the concept
 */
-class BumperEventRegister: public boost::enable_shared_from_this<BumperEventRegister>
+template<class T>
+class TouchEventRegister: public boost::enable_shared_from_this<TouchEventRegister<T> >
 {
 
 public:
@@ -59,9 +60,9 @@ public:
   /**
   * @brief Constructor for recorder interface
   */
-  BumperEventRegister();
-  BumperEventRegister(const std::string& name, const std::vector<std::string> keys, const float& frequency, const qi::SessionPtr& session );
-  ~BumperEventRegister();
+  TouchEventRegister();
+  TouchEventRegister(const std::string& name, const std::vector<std::string> keys, const float& frequency, const qi::SessionPtr& session );
+  ~TouchEventRegister();
 
   void resetPublisher( ros::NodeHandle& nh );
   void resetRecorder( boost::shared_ptr<naoqi::recorder::GlobalRecorder> gr );
@@ -77,6 +78,9 @@ public:
   void isDumping(bool state);
 
   void touchCallback(std::string &key, qi::AnyValue &value, qi::AnyValue &message);
+  void touchCallbackMessage(std::string &key, bool &state, naoqi_bridge_msgs::Bumper &msg);
+  void touchCallbackMessage(std::string &key, bool &state, naoqi_bridge_msgs::TactileTouch &msg);
+  
 
 private:
   void registerCallback();
@@ -84,15 +88,13 @@ private:
   void onEvent();
 
 private:
-  boost::shared_ptr<converter::TouchEventConverter<naoqi_bridge_msgs::Bumper> > converter_;
-  boost::shared_ptr<publisher::BasicPublisher<naoqi_bridge_msgs::Bumper> > publisher_;
-  //boost::shared_ptr<recorder::BasicEventRecorder<naoqi_bridge_msgs::Bumper> > recorder_;
+  boost::shared_ptr<converter::TouchEventConverter<T> > converter_;
+  boost::shared_ptr<publisher::BasicPublisher<T> > publisher_;
+  //boost::shared_ptr<recorder::BasicEventRecorder<T> > recorder_;
 
   qi::SessionPtr session_;
-  qi::AnyObject p_touch_;
   qi::AnyObject p_memory_;
   unsigned int serviceId;
-  std::vector<std::string> keys_;
   std::string name_;
 
   boost::mutex mutex_;
@@ -102,62 +104,41 @@ private:
   bool isRecording_;
   bool isDumping_;
 
+protected:
+  std::vector<std::string> keys_;
 }; // class
 
 
-class TactileTouchEventRegister: public boost::enable_shared_from_this<TactileTouchEventRegister>
+class BumperEventRegister: public TouchEventRegister<naoqi_bridge_msgs::Bumper>
 {
-
 public:
+  BumperEventRegister( const std::string& name, const std::vector<std::string> keys, const float& frequency, const qi::SessionPtr& session ) : TouchEventRegister<naoqi_bridge_msgs::Bumper>(name, keys, frequency, session) {}
+};
 
-  /**
-  * @brief Constructor for recorder interface
-  */
-  TactileTouchEventRegister();
-  TactileTouchEventRegister(const std::string& name, const std::vector<std::string> keys, const float& frequency, const qi::SessionPtr& session );
-  ~TactileTouchEventRegister();
+class TactileTouchEventRegister: public TouchEventRegister<naoqi_bridge_msgs::TactileTouch>
+{
+public:
+  TactileTouchEventRegister( const std::string& name, const std::vector<std::string> keys, const float& frequency, const qi::SessionPtr& session ) : TouchEventRegister<naoqi_bridge_msgs::TactileTouch>(name, keys, frequency, session) {}
+};
 
-  void resetPublisher( ros::NodeHandle& nh );
-  void resetRecorder( boost::shared_ptr<naoqi::recorder::GlobalRecorder> gr );
+//QI_REGISTER_OBJECT(BumperEventRegister, touchCallback)
+//QI_REGISTER_OBJECT(TactileTouchEventRegister, touchCallback)
 
-  void startProcess();
-  void stopProcess();
+static bool _qiregisterTouchEventRegisterBumper() {
+  ::qi::ObjectTypeBuilder<TouchEventRegister<naoqi_bridge_msgs::Bumper> > b;
+  QI_VAARGS_APPLY(__QI_REGISTER_ELEMENT, TouchEventRegister<naoqi_bridge_msgs::Bumper>, touchCallback)
+    b.registerType();
+  return true;
+  }
+static bool BOOST_PP_CAT(__qi_registration, __LINE__) = _qiregisterTouchEventRegisterBumper();
 
-  void writeDump(const ros::Time& time);
-  void setBufferDuration(float duration);
-
-  void isRecording(bool state);
-  void isPublishing(bool state);
-  void isDumping(bool state);
-
-  void touchCallback(std::string &key, qi::AnyValue &value, qi::AnyValue &message);
-
-private:
-  void registerCallback();
-  void unregisterCallback();
-  void onEvent();
-
-private:
-  boost::shared_ptr<converter::TouchEventConverter<naoqi_bridge_msgs::TactileTouch> > converter_;
-  boost::shared_ptr<publisher::BasicPublisher<naoqi_bridge_msgs::TactileTouch> > publisher_;
-  //boost::shared_ptr<recorder::BasicEventRecorder<naoqi_bridge_msgs::TactileTouch> > recorder_;
-
-  qi::SessionPtr session_;
-  qi::AnyObject p_touch_;
-  qi::AnyObject p_memory_;
-  unsigned int serviceId;
-  std::vector<std::string> keys_;
-  std::string name_;
-
-  boost::mutex mutex_;
-
-  bool isStarted_;
-  bool isPublishing_;
-  bool isRecording_;
-  bool isDumping_;
-
-}; // class
-
+static bool _qiregisterTouchEventRegisterTactileTouch() {
+  ::qi::ObjectTypeBuilder<TouchEventRegister<naoqi_bridge_msgs::TactileTouch> > b;
+  QI_VAARGS_APPLY(__QI_REGISTER_ELEMENT, TouchEventRegister<naoqi_bridge_msgs::TactileTouch>, touchCallback)
+    b.registerType();
+  return true;
+  }
+static bool BOOST_PP_CAT(__qi_registration, __LINE__) = _qiregisterTouchEventRegisterTactileTouch();
 
 } //naoqi
 

--- a/src/naoqi_driver.cpp
+++ b/src/naoqi_driver.cpp
@@ -25,6 +25,7 @@
  * CONVERTERS
  */
 #include "converters/audio.hpp"
+#include "converters/touch.hpp"
 #include "converters/camera.hpp"
 #include "converters/diagnostics.hpp"
 #include "converters/imu.hpp"
@@ -82,6 +83,7 @@
  */
 #include "event/basic.hpp"
 #include "event/audio.hpp"
+#include "event/touch.hpp"
 
 /*
  * STATIC FUNCTIONS INCLUDE
@@ -574,6 +576,8 @@ void Driver::registerDefaultConverter()
   bool sonar_enabled                  = boot_config_.get( "converters.sonar.enabled", true);
   size_t sonar_frequency              = boot_config_.get( "converters.sonar.frequency", 10);
 
+  bool bumper_enabled                 = boot_config_.get( "converters.bumper.enabled", true);
+  bool tactile_enabled                = boot_config_.get( "converters.tactile.enabled", true);
   /*
    * The info converter will be called once after it was added to the priority queue. Once it is its turn to be called, its
    * callAll method will be triggered (because InfoPublisher is considered to always have subscribers, isSubscribed always
@@ -757,6 +761,45 @@ void Driver::registerDefaultConverter()
       event_map_.find("audio")->second.isPublishing(true);
     }
   }
+
+  /** TOUCH **/
+  if ( bumper_enabled )
+  {
+    std::vector<std::string> bumper_events;
+    bumper_events.push_back("RightBumperPressed");
+    bumper_events.push_back("LeftBumperPressed");
+    if (robot_ == robot::PEPPER)
+    {
+      bumper_events.push_back("BackBumperPressed");
+    }
+    boost::shared_ptr<BumperEventRegister> event_register =
+      boost::make_shared<BumperEventRegister>( "bumper", bumper_events, 0, sessionPtr_ );
+    insertEventConverter("bumper", event_register);
+    if (keep_looping) {
+      event_map_.find("bumper")->second.startProcess();
+    }
+    if (publish_enabled_) {
+      event_map_.find("bumper")->second.isPublishing(true);
+    }
+  }
+
+  if ( tactile_enabled )
+  {
+    std::vector<std::string> tactile_touch_events;
+    tactile_touch_events.push_back("FrontTactilTouched");
+    tactile_touch_events.push_back("MiddleTactilTouched");
+    tactile_touch_events.push_back("RearTactilTouched");
+    boost::shared_ptr<TactileTouchEventRegister> event_register =
+      boost::make_shared<TactileTouchEventRegister>( "tactile_touch", tactile_touch_events, 0, sessionPtr_ );
+    insertEventConverter("tactile_touch", event_register);
+    if (keep_looping) {
+      event_map_.find("tactile_touch")->second.startProcess();
+    }
+    if (publish_enabled_) {
+      event_map_.find("tactile_touch")->second.isPublishing(true);
+    }
+  }
+
 }
 
 // public interface here


### PR DESCRIPTION
Ok, finally I found a way write event driven code instead of #48
This will provide equiavalent functions as we had in naoqi_tactile.py

QUESTIONS:

1) we had following error/warning message for every event callback, Any idea?
```
LeftBumperPressed 1
[E] 14911 qitype.object: No such property 100
[E] 14911 qitype.object: No such signal 100
LeftBumperPressed 0
[E] 14913 qitype.object: No such property 100
[E] 14913 qitype.object: No such signal 100
FrontTactilTouched 1
[E] 14912 qitype.object: No such property 100
[E] 14912 qitype.object: No such signal 100
```

2) I tried to write this using template class but it couldn't, even class inheretance...

I'm not c++ programmer so I missed something, but even if I was able to compile them, we had runtime error as follows...

```
found a catkin URDF /opt/ros/indigo/share/naoqi_driver/share/urdf/pepper.urdf
Audio Extractor: Start
terminate called after throwing an instance of 'std::runtime_error'
  what():  Object<T> can only be used on registered object types. (N5naoqi18TouchEventRegisterE)(0)
Aborted (core dumped)
```