### PR TITLE
register audio_enabled only when audio is set enabled

### DIFF
--- a/src/naoqi_driver.cpp
+++ b/src/naoqi_driver.cpp
@@ -746,7 +746,9 @@ void Driver::registerDefaultConverter()
     usc->registerCallback( message_actions::RECORD, boost::bind(&recorder::SonarRecorder::write, usr, _1) );
     usc->registerCallback( message_actions::LOG, boost::bind(&recorder::SonarRecorder::bufferize, usr, _1) );
     registerConverter( usc, usp, usr );
+  }
 
+  if ( audio_enabled ) {
     /** Audio */
     boost::shared_ptr<AudioEventRegister> event_register =
         boost::make_shared<AudioEventRegister>( "audio", 0, sessionPtr_ );


### PR DESCRIPTION
without this
```
diff --git a/share/boot_config.json b/share/boot_config.json
index f375f56..982b896 100644
--- a/share/boot_config.json
+++ b/share/boot_config.json
@@ -72,7 +72,7 @@
     },
     "audio":
     {
-      "enabled"       : true
+      "enabled"       : false
     }
   }
 }
``

didi not work