### PR TITLE
Add tactile and bumper in boot_config.json

### DIFF
--- a/share/boot_config.json
+++ b/share/boot_config.json
@@ -73,6 +73,14 @@
     "audio":
     {
       "enabled"       : true
+    },
+    "bumper":
+    {
+      "enabled"       : true
+    },
+    "tactile":
+    {
+      "enabled"       : true
     }
   }
 }


### PR DESCRIPTION
Just following PR #49 add the possibility to enable/disable tactile and bumper in boot_config.json