### PR TITLE
Add hand touch sensor input to touch event and converters

### DIFF
--- a/share/boot_config.json
+++ b/share/boot_config.json
@@ -82,6 +82,10 @@
     {
       "enabled"       : true
     },
+    "hand":
+    {
+      "enabled"       : true
+    },
     "odom":
     {
       "enabled"       : true,

--- a/src/converters/touch.cpp
+++ b/src/converters/touch.cpp
@@ -64,6 +64,7 @@ void TouchEventConverter<T>::callAll(const std::vector<message_actions::MessageA
 // http://stackoverflow.com/questions/8752837/undefined-reference-to-template-class-constructor
 template class TouchEventConverter<naoqi_bridge_msgs::Bumper>;
 template class TouchEventConverter<naoqi_bridge_msgs::TactileTouch>;
+template class TouchEventConverter<naoqi_bridge_msgs::HandTouch>;
 }
 
 }

--- a/src/converters/touch.hpp
+++ b/src/converters/touch.hpp
@@ -28,6 +28,7 @@
 * ROS includes
 */
 #include <naoqi_bridge_msgs/Bumper.h>
+#include <naoqi_bridge_msgs/HandTouch.h>
 #include <naoqi_bridge_msgs/TactileTouch.h>
 
 /*

--- a/src/event/touch.cpp
+++ b/src/event/touch.cpp
@@ -229,8 +229,22 @@ void TouchEventRegister<T>::touchCallbackMessage(std::string &key, bool &state, 
   }
 }
 
+template<class T>
+void TouchEventRegister<T>::touchCallbackMessage(std::string &key, bool &state, naoqi_bridge_msgs::HandTouch &msg)
+{
+  int i = 0;
+  for(std::vector<std::string>::const_iterator it = keys_.begin(); it != keys_.end(); ++it, ++i)
+  {
+    if ( key == it->c_str() ) {
+      msg.hand = i;
+      msg.state = state?(naoqi_bridge_msgs::HandTouch::statePressed):(naoqi_bridge_msgs::HandTouch::stateReleased);
+    }
+  }
+}
+
 // http://stackoverflow.com/questions/8752837/undefined-reference-to-template-class-constructor
 template class TouchEventRegister<naoqi_bridge_msgs::Bumper>;
 template class TouchEventRegister<naoqi_bridge_msgs::TactileTouch>;
+template class TouchEventRegister<naoqi_bridge_msgs::HandTouch>;
 
 }//namespace

--- a/src/event/touch.hpp
+++ b/src/event/touch.hpp
@@ -30,6 +30,7 @@
 #include <ros/ros.h>
 #include <naoqi_bridge_msgs/Bumper.h>
 #include <naoqi_bridge_msgs/TactileTouch.h>
+#include <naoqi_bridge_msgs/HandTouch.h>
 
 #include <naoqi_driver/tools.hpp>
 #include <naoqi_driver/recorder/globalrecorder.hpp>
@@ -80,6 +81,7 @@ public:
   void touchCallback(std::string &key, qi::AnyValue &value, qi::AnyValue &message);
   void touchCallbackMessage(std::string &key, bool &state, naoqi_bridge_msgs::Bumper &msg);
   void touchCallbackMessage(std::string &key, bool &state, naoqi_bridge_msgs::TactileTouch &msg);
+  void touchCallbackMessage(std::string &key, bool &state, naoqi_bridge_msgs::HandTouch &msg);
   
 
 private:
@@ -121,6 +123,12 @@ public:
   TactileTouchEventRegister( const std::string& name, const std::vector<std::string> keys, const float& frequency, const qi::SessionPtr& session ) : TouchEventRegister<naoqi_bridge_msgs::TactileTouch>(name, keys, frequency, session) {}
 };
 
+class HandTouchEventRegister: public TouchEventRegister<naoqi_bridge_msgs::HandTouch>
+{
+public:
+  HandTouchEventRegister( const std::string& name, const std::vector<std::string> keys, const float& frequency, const qi::SessionPtr& session ) : TouchEventRegister<naoqi_bridge_msgs::HandTouch>(name, keys, frequency, session) {}
+};
+
 //QI_REGISTER_OBJECT(BumperEventRegister, touchCallback)
 //QI_REGISTER_OBJECT(TactileTouchEventRegister, touchCallback)
 
@@ -139,6 +147,14 @@ static bool _qiregisterTouchEventRegisterTactileTouch() {
   return true;
   }
 static bool BOOST_PP_CAT(__qi_registration, __LINE__) = _qiregisterTouchEventRegisterTactileTouch();
+
+static bool _qiregisterTouchEventRegisterHandTouch() {
+  ::qi::ObjectTypeBuilder<TouchEventRegister<naoqi_bridge_msgs::HandTouch> > b;
+  QI_VAARGS_APPLY(__QI_REGISTER_ELEMENT, TouchEventRegister<naoqi_bridge_msgs::HandTouch>, touchCallback)
+    b.registerType();
+  return true;
+  }
+static bool BOOST_PP_CAT(__qi_registration, __LINE__) = _qiregisterTouchEventRegisterHandTouch();
 
 } //naoqi
 

--- a/src/naoqi_driver.cpp
+++ b/src/naoqi_driver.cpp
@@ -584,6 +584,7 @@ void Driver::registerDefaultConverter()
 
   bool bumper_enabled                 = boot_config_.get( "converters.bumper.enabled", true);
   bool tactile_enabled                = boot_config_.get( "converters.tactile.enabled", true);
+  bool hand_enabled                   = boot_config_.get( "converters.hand.enabled", true);
   /*
    * The info converter will be called once after it was added to the priority queue. Once it is its turn to be called, its
    * callAll method will be triggered (because InfoPublisher is considered to always have subscribers, isSubscribed always
@@ -807,6 +808,25 @@ void Driver::registerDefaultConverter()
     }
   }
 
+  if ( hand_enabled )
+    {
+      std::vector<std::string> hand_touch_events;
+      hand_touch_events.push_back("HandRightBackTouched");
+      hand_touch_events.push_back("HandRightLeftTouched");
+      hand_touch_events.push_back("HandRightRightTouched");
+      hand_touch_events.push_back("HandLeftBackTouched");
+      hand_touch_events.push_back("HandLeftLeftTouched");
+      hand_touch_events.push_back("HandLeftRightTouched");
+      boost::shared_ptr<HandTouchEventRegister> event_register =
+	boost::make_shared<HandTouchEventRegister>( "hand_touch", hand_touch_events, 0, sessionPtr_ );
+      insertEventConverter("hand_touch", event_register);
+      if (keep_looping) {
+	event_map_.find("hand_touch")->second.startProcess();
+      }
+      if (publish_enabled_) {
+	event_map_.find("hand_touch")->second.isPublishing(true);
+      }
+    }
   
   /** Odom */
   if ( odom_enabled )


### PR DESCRIPTION
I tried my changes with 
Nao (Naoqi version 2.1.4.13)
Pepper (Naoqi version 2.4.2.26).

I executed `roslaunch naoqi_driver naoqi_driver.launch`,  
`rostopic echo /naoqi_driver_node/hand_touch` and touched Nao/ Pepper's hands.

The results are as follows:

```
hand: 3
state: 1
---
hand: 3
state: 0
---
hand: 5
state: 1
---
```

If there are any problems, please let me know.
