### PR TITLE
modified CameraDepth_sensor_fixedjoint z value to fit rgb image and depth image

### DIFF
--- a/share/urdf/pepper.urdf
+++ b/share/urdf/pepper.urdf
@@ -569,7 +569,7 @@
   <joint name="CameraDepth_sensor_fixedjoint" type="fixed">
     <parent link="Head"/>
     <child link="CameraDepth_frame"/>
-    <origin rpy="0 0 0" xyz="0.05138 0.039 0.1194"/>
+    <origin rpy="0 0 0" xyz="0.05138 0.039 0.2374"/>
     <axis xyz="0 0 0"/>
   </joint>
   <link name="SurroundingRightLaser_frame"/>


### PR DESCRIPTION
I modified z value of CameraDepth_sensor_fixedjoint to fit rgb (```pepper_robot/camera/front/image_raw```) and depth image (```pepper_robot/camera/depth/image_raw```) of pepper.
I modified z value just by my eyes. 
I'd like to have a review on this.

pepper's pointcloud view before modified z value
![before_modified_joint_z_value](https://cloud.githubusercontent.com/assets/7259671/15924750/acd9280e-2e6e-11e6-9bec-8a33971ae944.png)

```
rosrun tf tf_echo CameraTop_optical_frame CameraDepth_optical_frame 10

At time 1465464133.728
- Translation: [0.039, 0.044, 0.035]
- Rotation: in Quaternion [0.000, 0.000, 0.000, 1.000]
            in RPY (radian) [0.000, -0.000, 0.000]
            in RPY (degree) [0.000, -0.000, 0.000]
```
I used this program to publish pepper's pointcloud.
```
<launch>
  <node pkg="tf" name="depth_to_top_camera_frame_publisher" type="static_transform_publisher" args="0.039 0.044 0.035 0.000 0.000 0.000 CameraTop_optical_frame CameraDepth_optical_frame 1"/>
  <node pkg="image_proc" type="image_proc" name="rgb_processing" output="screen" ns="/pepper_robot/camera/front">
  </node>

  <node pkg="nodelet" type="nodelet" name="register_depth" output="screen"
        args="standalone depth_image_proc/register" >
    <remap from="rgb/camera_info" to="/pepper_robot/camera/front/camera_info"/>
    <remap from="depth/camera_info" to="/pepper_robot/camera/depth/camera_info"/>
    <remap from="depth/image_rect" to="/pepper_robot/camera/depth/image_raw"/>
    <remap from="depth_registered/camera_info" to="/pepper_robot/camera/depth_registered/camera_info"/>
    <remap from="depth_registered/image_rect" to="/pepper_robot/camera/depth_registered/image_rect"/>
  </node>

  <node pkg="nodelet" type="nodelet" name="cloudify" output="screen"
        args="standalone depth_image_proc/point_cloud_xyzrgb" >
    <remap from="rgb/camera_info" to="/pepper_robot/camera/front/camera_info"/>
    <remap from="rgb/image_rect_color" to="/pepper_robot/camera/front/image_rect_color"/>
    <remap from="depth_registered/image_rect" to="/pepper_robot/camera/depth_registered/image_rect"/>
    <remap from="depth_registered/points" to="/pepper_robot/camera/depth/points"/>
  </node>
</launch>
```

pepper's pointcloud view after I modified z value
![after_modified_joint_z_value](https://cloud.githubusercontent.com/assets/7259671/15924586/cf2e5f24-2e6d-11e6-839b-9b9f49b5ab55.png)

```
rosrun tf tf_echo CameraTop_optical_frame CameraDepth_optical_frame 10

At time 1465463676.955
- Translation: [0.039, 0.074, 0.035]
- Rotation: in Quaternion [0.000, 0.000, 0.000, 1.000]
            in RPY (radian) [0.000, -0.000, 0.000]
            in RPY (degree) [0.000, -0.000, 0.000]
```
I used this program to publish pepper's pointcloud. 
What I changed is only
```
 <node pkg="tf" name="depth_to_top_camera_frame_publisher" type="static_transform_publisher" args="0.039 0.074 0.035 0.000 0.000 0.000 CameraTop_optical_frame CameraDepth_optical_frame 1"/>
```

```
<launch>
  <node pkg="tf" name="depth_to_top_camera_frame_publisher" type="static_transform_publisher" args="0.039 0.074 0.035 0.000 0.000 0.000 CameraTop_optical_frame CameraDepth_optical_frame 1"/>
  <node pkg="image_proc" type="image_proc" name="rgb_processing" output="screen" ns="/pepper_robot/camera/front">
  </node>

  <node pkg="nodelet" type="nodelet" name="register_depth" output="screen"
        args="standalone depth_image_proc/register" >
    <remap from="rgb/camera_info" to="/pepper_robot/camera/front/camera_info"/>
    <remap from="depth/camera_info" to="/pepper_robot/camera/depth/camera_info"/>
    <remap from="depth/image_rect" to="/pepper_robot/camera/depth/image_raw"/>
    <remap from="depth_registered/camera_info" to="/pepper_robot/camera/depth_registered/camera_info"/>
    <remap from="depth_registered/image_rect" to="/pepper_robot/camera/depth_registered/image_rect"/>
  </node>

  <node pkg="nodelet" type="nodelet" name="cloudify" output="screen"
        args="standalone depth_image_proc/point_cloud_xyzrgb" >
    <remap from="rgb/camera_info" to="/pepper_robot/camera/front/camera_info"/>
    <remap from="rgb/image_rect_color" to="/pepper_robot/camera/front/image_rect_color"/>
    <remap from="depth_registered/image_rect" to="/pepper_robot/camera/depth_registered/image_rect"/>
    <remap from="depth_registered/points" to="/pepper_robot/camera/depth/points"/>
  </node>
</launch>
```
