### PR TITLE
[share/boot_config.json] increase frequency for publishing joint_states

### DIFF
--- a/share/boot_config.json
+++ b/share/boot_config.json
@@ -58,7 +58,7 @@
     "joint_states":
     {
       "enabled"       : true,
-      "frequency"     : 15
+      "frequency"     : 50
     },
     "laser":
     {

--- a/src/naoqi_driver.cpp
+++ b/src/naoqi_driver.cpp
@@ -569,7 +569,7 @@ void Driver::registerDefaultConverter()
   size_t camera_ir_recorder_fps       = boot_config_.get( "converters.ir_camera.recorder_fps", 5);
 
   bool joint_states_enabled           = boot_config_.get( "converters.joint_states.enabled", true);
-  size_t joint_states_frequency       = boot_config_.get( "converters.joint_states.frequency", 15);
+  size_t joint_states_frequency       = boot_config_.get( "converters.joint_states.frequency", 50);
 
   bool laser_enabled                  = boot_config_.get( "converters.laser.enabled", true);
   size_t laser_frequency              = boot_config_.get( "converters.laser.frequency", 10);


### PR DESCRIPTION
Current frequency of publishing `joint_states` and `tf` is too slow to synchronize sensors with tf frames especially `color` and `depth` cameras.
By this pull request the frequency is changed from `15` Hz to `100` Hz, which is enough for depth registration.
(also see discuss at https://github.com/ros-naoqi/pepper_robot/pull/27)