### PR TITLE
kRawDepthColorSpace for depth image

### DIFF
--- a/src/converters/camera.cpp
+++ b/src/converters/camera.cpp
@@ -126,7 +126,7 @@ CameraConverter::CameraConverter( const std::string& name, const float& frequenc
     camera_source_(camera_source),
     resolution_(resolution),
     // change in case of depth camera
-    colorspace_( (camera_source_!=AL::kDepthCamera)?AL::kRGBColorSpace:AL::kDepthColorSpace ),
+    colorspace_( (camera_source_!=AL::kDepthCamera)?AL::kRGBColorSpace:AL::kRawDepthColorSpace ),
     msg_colorspace_( (camera_source_!=AL::kDepthCamera)?"rgb8":"16UC1" ),
     cv_mat_type_( (camera_source_!=AL::kDepthCamera)?CV_8UC3:CV_16U ),
     camera_info_( camera_info_definitions::getCameraInfo(camera_source, resolution) )

--- a/src/tools/alvisiondefinitions.h
+++ b/src/tools/alvisiondefinitions.h
@@ -78,7 +78,8 @@ namespace AL
   const int kXYZColorSpace = 19;
   const int kInfraredColorSpace = 20;
   const int kDistanceColorSpace = 21;
-
+  const int kRawDepthColorSpace = 23;
+      
   const int kCameraBrightnessID       = 0;
   const int kCameraContrastID         = 1;
   const int kCameraSaturationID       = 2;


### PR DESCRIPTION
This pull request is to use ```kRawDepthColorSpace``` instead of ```kDepthColorSpace``` for depth image. 

The point cloud from ```kRawDepthColorSpace``` is more clear.
kDepthColorSpace + with black lenses:
![pepper_with_lens_kdepthimagecolorspace](https://cloud.githubusercontent.com/assets/7259671/18504857/5dbf8970-7a9f-11e6-9800-c2e7ed5347a7.png)

kRawDepthColorSpace + with black lenses:
![pepper_with_lens_krawdepthimagecolorspace](https://cloud.githubusercontent.com/assets/7259671/18504868/676780cc-7a9f-11e6-8de3-11c4f7c88f7d.png)

kDepthColorSpace + without black lenses:
![pepper_without_lens_kdepthimagecolorspace](https://cloud.githubusercontent.com/assets/7259671/18504874/6cf78852-7a9f-11e6-9cf2-daab9f575af1.png)

kRawDepthColorSpace + with black lenses:
![pepper_without_lens_krawdepthimagecolorspace](https://cloud.githubusercontent.com/assets/7259671/18504883/77576a60-7a9f-11e6-9c59-56386f8cf873.png)

reference
https://github.com/jsk-ros-pkg/jsk_robot/issues/619
(The last comment says that ```kRawDepthColorSpace``` has a strong effect when eye covers are removed.)
https://github.com/ros-naoqi/pepper_robot/pull/27
(The last comment says that ```kRawDepthColorSpace``` will be required for SLAM.)
