### PR TITLE
rename tactile touch to head touch

### DIFF
--- a/share/boot_config.json
+++ b/share/boot_config.json
@@ -78,11 +78,11 @@
     {
       "enabled"       : true
     },
-    "tactile":
+    "hand":
     {
       "enabled"       : true
     },
-    "hand":
+    "head":
     {
       "enabled"       : true
     },

--- a/share/boot_config.json
+++ b/share/boot_config.json
@@ -78,11 +78,11 @@
     {
       "enabled"       : true
     },
-    "hand":
+    "touch_hand":
     {
       "enabled"       : true
     },
-    "head":
+    "touch_head":
     {
       "enabled"       : true
     },

--- a/src/converters/touch.cpp
+++ b/src/converters/touch.cpp
@@ -63,8 +63,8 @@ void TouchEventConverter<T>::callAll(const std::vector<message_actions::MessageA
 
 // http://stackoverflow.com/questions/8752837/undefined-reference-to-template-class-constructor
 template class TouchEventConverter<naoqi_bridge_msgs::Bumper>;
-template class TouchEventConverter<naoqi_bridge_msgs::TactileTouch>;
 template class TouchEventConverter<naoqi_bridge_msgs::HandTouch>;
+template class TouchEventConverter<naoqi_bridge_msgs::HeadTouch>;
 }
 
 }

--- a/src/converters/touch.hpp
+++ b/src/converters/touch.hpp
@@ -29,7 +29,7 @@
 */
 #include <naoqi_bridge_msgs/Bumper.h>
 #include <naoqi_bridge_msgs/HandTouch.h>
-#include <naoqi_bridge_msgs/TactileTouch.h>
+#include <naoqi_bridge_msgs/HeadTouch.h>
 
 /*
 * ALDEBARAN includes

--- a/src/event/touch.cpp
+++ b/src/event/touch.cpp
@@ -217,19 +217,6 @@ void TouchEventRegister<T>::touchCallbackMessage(std::string &key, bool &state, 
 }
 
 template<class T>
-void TouchEventRegister<T>::touchCallbackMessage(std::string &key, bool &state, naoqi_bridge_msgs::TactileTouch &msg)
-{
-  int i = 0;
-  for(std::vector<std::string>::const_iterator it = keys_.begin(); it != keys_.end(); ++it, ++i)
-  {
-    if ( key == it->c_str() ) {
-      msg.button = i;
-      msg.state = state?(naoqi_bridge_msgs::TactileTouch::statePressed):(naoqi_bridge_msgs::TactileTouch::stateReleased);
-    }
-  }
-}
-
-template<class T>
 void TouchEventRegister<T>::touchCallbackMessage(std::string &key, bool &state, naoqi_bridge_msgs::HandTouch &msg)
 {
   int i = 0;
@@ -242,9 +229,22 @@ void TouchEventRegister<T>::touchCallbackMessage(std::string &key, bool &state, 
   }
 }
 
+template<class T>
+void TouchEventRegister<T>::touchCallbackMessage(std::string &key, bool &state, naoqi_bridge_msgs::HeadTouch &msg)
+{
+  int i = 0;
+  for(std::vector<std::string>::const_iterator it = keys_.begin(); it != keys_.end(); ++it, ++i)
+  {
+    if ( key == it->c_str() ) {
+      msg.button = i;
+      msg.state = state?(naoqi_bridge_msgs::HeadTouch::statePressed):(naoqi_bridge_msgs::HeadTouch::stateReleased);
+    }
+  }
+}
+
 // http://stackoverflow.com/questions/8752837/undefined-reference-to-template-class-constructor
 template class TouchEventRegister<naoqi_bridge_msgs::Bumper>;
-template class TouchEventRegister<naoqi_bridge_msgs::TactileTouch>;
 template class TouchEventRegister<naoqi_bridge_msgs::HandTouch>;
+template class TouchEventRegister<naoqi_bridge_msgs::HeadTouch>;
 
 }//namespace

--- a/src/event/touch.hpp
+++ b/src/event/touch.hpp
@@ -29,8 +29,8 @@
 
 #include <ros/ros.h>
 #include <naoqi_bridge_msgs/Bumper.h>
-#include <naoqi_bridge_msgs/TactileTouch.h>
 #include <naoqi_bridge_msgs/HandTouch.h>
+#include <naoqi_bridge_msgs/HeadTouch.h>
 
 #include <naoqi_driver/tools.hpp>
 #include <naoqi_driver/recorder/globalrecorder.hpp>
@@ -80,8 +80,8 @@ public:
 
   void touchCallback(std::string &key, qi::AnyValue &value, qi::AnyValue &message);
   void touchCallbackMessage(std::string &key, bool &state, naoqi_bridge_msgs::Bumper &msg);
-  void touchCallbackMessage(std::string &key, bool &state, naoqi_bridge_msgs::TactileTouch &msg);
   void touchCallbackMessage(std::string &key, bool &state, naoqi_bridge_msgs::HandTouch &msg);
+  void touchCallbackMessage(std::string &key, bool &state, naoqi_bridge_msgs::HeadTouch &msg);
   
 
 private:
@@ -117,10 +117,10 @@ public:
   BumperEventRegister( const std::string& name, const std::vector<std::string> keys, const float& frequency, const qi::SessionPtr& session ) : TouchEventRegister<naoqi_bridge_msgs::Bumper>(name, keys, frequency, session) {}
 };
 
-class TactileTouchEventRegister: public TouchEventRegister<naoqi_bridge_msgs::TactileTouch>
+class HeadTouchEventRegister: public TouchEventRegister<naoqi_bridge_msgs::HeadTouch>
 {
 public:
-  TactileTouchEventRegister( const std::string& name, const std::vector<std::string> keys, const float& frequency, const qi::SessionPtr& session ) : TouchEventRegister<naoqi_bridge_msgs::TactileTouch>(name, keys, frequency, session) {}
+  HeadTouchEventRegister( const std::string& name, const std::vector<std::string> keys, const float& frequency, const qi::SessionPtr& session ) : TouchEventRegister<naoqi_bridge_msgs::HeadTouch>(name, keys, frequency, session) {}
 };
 
 class HandTouchEventRegister: public TouchEventRegister<naoqi_bridge_msgs::HandTouch>
@@ -130,7 +130,7 @@ public:
 };
 
 //QI_REGISTER_OBJECT(BumperEventRegister, touchCallback)
-//QI_REGISTER_OBJECT(TactileTouchEventRegister, touchCallback)
+//QI_REGISTER_OBJECT(HeadTouchEventRegister, touchCallback)
 
 static bool _qiregisterTouchEventRegisterBumper() {
   ::qi::ObjectTypeBuilder<TouchEventRegister<naoqi_bridge_msgs::Bumper> > b;
@@ -140,14 +140,6 @@ static bool _qiregisterTouchEventRegisterBumper() {
   }
 static bool BOOST_PP_CAT(__qi_registration, __LINE__) = _qiregisterTouchEventRegisterBumper();
 
-static bool _qiregisterTouchEventRegisterTactileTouch() {
-  ::qi::ObjectTypeBuilder<TouchEventRegister<naoqi_bridge_msgs::TactileTouch> > b;
-  QI_VAARGS_APPLY(__QI_REGISTER_ELEMENT, TouchEventRegister<naoqi_bridge_msgs::TactileTouch>, touchCallback)
-    b.registerType();
-  return true;
-  }
-static bool BOOST_PP_CAT(__qi_registration, __LINE__) = _qiregisterTouchEventRegisterTactileTouch();
-
 static bool _qiregisterTouchEventRegisterHandTouch() {
   ::qi::ObjectTypeBuilder<TouchEventRegister<naoqi_bridge_msgs::HandTouch> > b;
   QI_VAARGS_APPLY(__QI_REGISTER_ELEMENT, TouchEventRegister<naoqi_bridge_msgs::HandTouch>, touchCallback)
@@ -155,6 +147,14 @@ static bool _qiregisterTouchEventRegisterHandTouch() {
   return true;
   }
 static bool BOOST_PP_CAT(__qi_registration, __LINE__) = _qiregisterTouchEventRegisterHandTouch();
+
+static bool _qiregisterTouchEventRegisterHeadTouch() {
+  ::qi::ObjectTypeBuilder<TouchEventRegister<naoqi_bridge_msgs::HeadTouch> > b;
+  QI_VAARGS_APPLY(__QI_REGISTER_ELEMENT, TouchEventRegister<naoqi_bridge_msgs::HeadTouch>, touchCallback)
+    b.registerType();
+  return true;
+  }
+static bool BOOST_PP_CAT(__qi_registration, __LINE__) = _qiregisterTouchEventRegisterHeadTouch();
 
 } //naoqi
 

--- a/src/naoqi_driver.cpp
+++ b/src/naoqi_driver.cpp
@@ -582,8 +582,8 @@ void Driver::registerDefaultConverter()
   size_t odom_frequency              = boot_config_.get( "converters.odom.frequency", 10);
   
   bool bumper_enabled                 = boot_config_.get( "converters.bumper.enabled", true);
-  bool hand_enabled                   = boot_config_.get( "converters.hand.enabled", true);
-  bool head_enabled                   = boot_config_.get( "converters.head.enabled", true);
+  bool hand_enabled                   = boot_config_.get( "converters.touch_hand.enabled", true);
+  bool head_enabled                   = boot_config_.get( "converters.touch_head.enabled", true);
   /*
    * The info converter will be called once after it was added to the priority queue. Once it is its turn to be called, its
    * callAll method will be triggered (because InfoPublisher is considered to always have subscribers, isSubscribed always

--- a/src/naoqi_driver.cpp
+++ b/src/naoqi_driver.cpp
@@ -581,10 +581,9 @@ void Driver::registerDefaultConverter()
   bool odom_enabled                  = boot_config_.get( "converters.odom.enabled", true);
   size_t odom_frequency              = boot_config_.get( "converters.odom.frequency", 10);
   
-
   bool bumper_enabled                 = boot_config_.get( "converters.bumper.enabled", true);
-  bool tactile_enabled                = boot_config_.get( "converters.tactile.enabled", true);
   bool hand_enabled                   = boot_config_.get( "converters.hand.enabled", true);
+  bool head_enabled                   = boot_config_.get( "converters.head.enabled", true);
   /*
    * The info converter will be called once after it was added to the priority queue. Once it is its turn to be called, its
    * callAll method will be triggered (because InfoPublisher is considered to always have subscribers, isSubscribed always
@@ -791,42 +790,42 @@ void Driver::registerDefaultConverter()
     }
   }
 
-  if ( tactile_enabled )
+  if ( hand_enabled )
   {
-    std::vector<std::string> tactile_touch_events;
-    tactile_touch_events.push_back("FrontTactilTouched");
-    tactile_touch_events.push_back("MiddleTactilTouched");
-    tactile_touch_events.push_back("RearTactilTouched");
-    boost::shared_ptr<TactileTouchEventRegister> event_register =
-      boost::make_shared<TactileTouchEventRegister>( "tactile_touch", tactile_touch_events, 0, sessionPtr_ );
-    insertEventConverter("tactile_touch", event_register);
+    std::vector<std::string> hand_touch_events;
+    hand_touch_events.push_back("HandRightBackTouched");
+    hand_touch_events.push_back("HandRightLeftTouched");
+    hand_touch_events.push_back("HandRightRightTouched");
+    hand_touch_events.push_back("HandLeftBackTouched");
+    hand_touch_events.push_back("HandLeftLeftTouched");
+    hand_touch_events.push_back("HandLeftRightTouched");
+    boost::shared_ptr<HandTouchEventRegister> event_register =
+      boost::make_shared<HandTouchEventRegister>( "hand_touch", hand_touch_events, 0, sessionPtr_ );
+    insertEventConverter("hand_touch", event_register);
     if (keep_looping) {
-      event_map_.find("tactile_touch")->second.startProcess();
+      event_map_.find("hand_touch")->second.startProcess();
     }
     if (publish_enabled_) {
-      event_map_.find("tactile_touch")->second.isPublishing(true);
+      event_map_.find("hand_touch")->second.isPublishing(true);
     }
   }
 
-  if ( hand_enabled )
-    {
-      std::vector<std::string> hand_touch_events;
-      hand_touch_events.push_back("HandRightBackTouched");
-      hand_touch_events.push_back("HandRightLeftTouched");
-      hand_touch_events.push_back("HandRightRightTouched");
-      hand_touch_events.push_back("HandLeftBackTouched");
-      hand_touch_events.push_back("HandLeftLeftTouched");
-      hand_touch_events.push_back("HandLeftRightTouched");
-      boost::shared_ptr<HandTouchEventRegister> event_register =
-	boost::make_shared<HandTouchEventRegister>( "hand_touch", hand_touch_events, 0, sessionPtr_ );
-      insertEventConverter("hand_touch", event_register);
-      if (keep_looping) {
-	event_map_.find("hand_touch")->second.startProcess();
-      }
-      if (publish_enabled_) {
-	event_map_.find("hand_touch")->second.isPublishing(true);
-      }
+  if ( head_enabled )
+  {
+    std::vector<std::string> head_touch_events;
+    head_touch_events.push_back("FrontTactilTouched");
+    head_touch_events.push_back("MiddleTactilTouched");
+    head_touch_events.push_back("RearTactilTouched");
+    boost::shared_ptr<HeadTouchEventRegister> event_register =
+      boost::make_shared<HeadTouchEventRegister>( "head_touch", head_touch_events, 0, sessionPtr_ );
+    insertEventConverter("head_touch", event_register);
+    if (keep_looping) {
+      event_map_.find("head_touch")->second.startProcess();
     }
+    if (publish_enabled_) {
+      event_map_.find("head_touch")->second.isPublishing(true);
+    }
+  }
   
   /** Odom */
   if ( odom_enabled )


### PR DESCRIPTION
Based on the discussion in https://github.com/ros-naoqi/naoqi_bridge_msgs/pull/4,
I renamed tactileTouch (for head touch sensor) to headTouch.
In addtion, put it and handTouch in an alphabetical order.

It requires https://github.com/ros-naoqi/naoqi_bridge_msgs/pull/29 .

One concern is that even though renaming TactileTouch to HeadTouch would be more easy to follow for me, it may have an effect on TactileTouch topic users.

If there is any problem/ comment, please let me know.