### PR TITLE
Adding people perception and other things

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ set(
 set(
   SERVICES_SRC
   src/services/robot_config.cpp
+  src/services/behavior_manager.cpp
   )
 
 set(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ set(
   src/subscribers/teleop.cpp
   src/subscribers/moveto.cpp
   src/subscribers/speech.cpp
+  src/subscribers/animated_speech.cpp
   )
 
 set(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ set(
   CONVERTERS_SRC
   src/converters/audio.cpp
   src/converters/touch.cpp
+  src/converters/people.cpp
   src/converters/camera.cpp
   src/converters/diagnostics.cpp
   src/converters/imu.cpp
@@ -66,6 +67,7 @@ set(
   src/event/basic.hpp
   src/event/audio.cpp
   src/event/touch.cpp
+  src/event/people.cpp
   )
 
 # use catkin if qibuild is not found

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ set(
   src/converters/log.cpp
   src/converters/odom.cpp
   src/converters/battery.cpp
+  src/converters/odom.cpp
   )
 set(
   TOOLS_SRC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ set(
   src/converters/sonar.cpp
   src/converters/log.cpp
   src/converters/odom.cpp
+  src/converters/battery.cpp
   )
 set(
   TOOLS_SRC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ set(
   src/subscribers/moveto.cpp
   src/subscribers/speech.cpp
   src/subscribers/animated_speech.cpp
+  src/subscribers/play_animation.cpp
   )
 
 set(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ set(
   src/converters/odom.cpp
   src/converters/battery.cpp
   src/converters/odom.cpp
+  src/converters/sound.cpp
   )
 set(
   TOOLS_SRC
@@ -72,6 +73,7 @@ set(
   src/event/audio.cpp
   src/event/touch.cpp
   src/event/people.cpp
+  src/event/sound.cpp
   )
 
 # use catkin if qibuild is not found

--- a/CMakeLists_catkin.txt
+++ b/CMakeLists_catkin.txt
@@ -11,6 +11,7 @@ find_package(catkin COMPONENTS
   image_transport
   kdl_parser
   naoqi_bridge_msgs
+  nao_interaction_msgs
   naoqi_libqi
   naoqi_libqicore
   robot_state_publisher

--- a/CMakeLists_catkin.txt
+++ b/CMakeLists_catkin.txt
@@ -18,6 +18,7 @@ find_package(catkin COMPONENTS
   rosbag_storage
   rosgraph_msgs
   sensor_msgs
+  std_srvs
   tf2_geometry_msgs
   tf2_msgs
   tf2_ros

--- a/launch/register_depth.launch
+++ b/launch/register_depth.launch
@@ -1,0 +1,29 @@
+<launch>
+<!--  <node pkg="tf" name="depth_to_top_camera_frame_publisher" type="static_transform_publisher" args="0.039 0.044 0.035 0.000 0.000 0.000 CameraTop_optical_frame CameraDepth_optical_frame 1"/>
+  <node pkg="tf" name="depth_to_top_camera_frame_publisher" type="static_transform_publisher" args="-0.05 0.12 0.0 0.0 0.0 -0.07 CameraTop_optical_frame CameraDepth_optical_frame 1"/>
+  
+-->
+  <node pkg="tf" name="depth_to_top_camera_frame_publisher" type="static_transform_publisher" args="-0.035 0.03 0.035 0.0 0.0 -0.07 CameraTop_optical_frame CameraDepth_optical_frame 1"/>
+  
+  <node pkg="image_proc" type="image_proc" name="rgb_processing" output="screen" ns="/naoqi_driver_node/camera/front" />
+
+  <node pkg="nodelet" type="nodelet" name="register_depth" output="screen"
+        args="standalone depth_image_proc/register" >
+    <remap from="rgb/camera_info" to="/naoqi_driver_node/camera/front/camera_info"/>
+    <remap from="depth/camera_info" to="/naoqi_driver_node/camera/depth/camera_info"/>
+    <remap from="depth/image_rect" to="/naoqi_driver_node/camera/depth/image_raw"/>
+    <remap from="depth_registered/camera_info" to="/naoqi_driver_node/camera/depth_registered/camera_info"/>
+    <remap from="depth_registered/image_rect" to="/naoqi_driver_node/camera/depth_registered/image_rect"/>
+  </node>
+
+  <node pkg="nodelet" type="nodelet" name="cloudify" output="screen"
+        args="standalone depth_image_proc/point_cloud_xyzrgb" >
+    <remap from="rgb/camera_info" to="/naoqi_driver_node/camera/front/camera_info"/>
+    <remap from="rgb/image_rect_color" to="/naoqi_driver_node/camera/front/image_rect_color"/>
+    <remap from="depth_registered/image_rect" to="/naoqi_driver_node/camera/depth_registered/image_rect"/>
+    <remap from="depth_registered/points" to="/naoqi_driver_node/camera/depth_registered/points"/>
+  </node>
+</launch>
+
+
+

--- a/package.xml
+++ b/package.xml
@@ -18,6 +18,7 @@
   <build_depend>image_transport</build_depend>
   <build_depend>kdl_parser</build_depend>
   <build_depend version_gte="0.0.4">naoqi_bridge_msgs</build_depend>
+  <build_depend>nao_interaction_msgs</build_depend>
   <build_depend>naoqi_libqi</build_depend>
   <build_depend>naoqi_libqicore</build_depend>
   <build_depend>orocos_kdl</build_depend>
@@ -36,6 +37,7 @@
   <run_depend>image_transport</run_depend>
   <run_depend>kdl_parser</run_depend>
   <run_depend version_gte="0.0.4">naoqi_bridge_msgs</run_depend>
+  <run_depend>nao_interaction_msgs</run_depend>
   <run_depend>naoqi_libqi</run_depend>
   <run_depend>naoqi_libqicore</run_depend>
   <run_depend>orocos_kdl</run_depend>

--- a/package.xml
+++ b/package.xml
@@ -26,6 +26,7 @@
   <build_depend>rosbag_storage</build_depend>
   <build_depend>rosgraph_msgs</build_depend>
   <build_depend>sensor_msgs</build_depend>
+  <build_depend>std_srvs</build_depend>
   <build_depend>tf2_geometry_msgs</build_depend>
   <build_depend>tf2_msgs</build_depend>
   <build_depend>tf2_ros</build_depend>

--- a/share/boot_config.json
+++ b/share/boot_config.json
@@ -78,7 +78,7 @@
     {
       "enabled"       : true
     },
-    "tactile":
+    "people":
     {
       "enabled"       : true
     },

--- a/share/boot_config.json
+++ b/share/boot_config.json
@@ -76,10 +76,10 @@
       "frequency"     : 10
     },
     "odom":
-        {
-          "enabled"       : true,
-          "frequency"     : 15
-        },
+    {
+      "enabled"       : true,
+      "frequency"     : 15
+    },
     "audio":
     {
       "enabled"       : true

--- a/share/boot_config.json
+++ b/share/boot_config.json
@@ -70,6 +70,11 @@
       "enabled"       : true,
       "frequency"     : 10
     },
+    "battery":
+    {
+      "enabled"       : true,
+      "frequency"     : 10
+    },
     "audio":
     {
       "enabled"       : true

--- a/share/boot_config.json
+++ b/share/boot_config.json
@@ -84,6 +84,12 @@
     {
       "enabled"       : true
     },
+    "sound":
+    {
+      "enabled"       : true,
+      "energy"        : true,
+      "sensitivity"   : 0.9
+    },
     "bumper":
     {
       "enabled"       : true

--- a/share/boot_config.json
+++ b/share/boot_config.json
@@ -75,6 +75,11 @@
       "enabled"       : true,
       "frequency"     : 10
     },
+    "odom":
+        {
+          "enabled"       : true,
+          "frequency"     : 15
+        },
     "audio":
     {
       "enabled"       : true

--- a/share/boot_config.json
+++ b/share/boot_config.json
@@ -78,6 +78,10 @@
     {
       "enabled"       : true
     },
+    "face":
+    {
+      "enabled"       : true
+    },
     "people":
     {
       "enabled"       : true

--- a/src/converters/battery.cpp
+++ b/src/converters/battery.cpp
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2015 Aldebaran
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+/*
+* LOCAL includes
+*/
+#include "battery.hpp"
+#include "../tools/from_any_value.hpp"
+
+/*
+* BOOST includes
+*/
+#include <boost/foreach.hpp>
+#define for_each BOOST_FOREACH
+
+namespace naoqi
+{
+namespace converter
+{
+
+BatteryConverter::BatteryConverter( const std::string& name, const float& frequency, const qi::SessionPtr& session )
+  : BaseConverter( name, frequency, session ),
+    p_memory_( session->service("ALMemory") ),
+    p_battery_( session->service("ALBattery") ),
+    is_subscribed_(false)
+{
+  std::vector<std::string> keys;
+  keys.push_back("Device/SubDeviceList/Battery/Charge/Sensor/Value");
+  keys.push_back("Device/SubDeviceList/Battery/Charge/Sensor/TotalVoltage");
+  keys.push_back("Device/SubDeviceList/Battery/Current/Sensor/Value");
+  keys.push_back("Device/SubDeviceList/Platform/ILS/Sensor/Value");
+  keys.push_back("Device/SubDeviceList/Battery/Charge/Sensor/Charging");
+  keys.push_back("ALBattery/ConnectedToChargingStation"); 
+
+  keys_.resize(keys.size());
+  size_t i = 0;
+  for(std::vector<std::string>::const_iterator it = keys.begin(); it != keys.end(); ++it, ++i)
+    keys_[i] = *it;
+}
+
+BatteryConverter::~BatteryConverter()
+{
+  if (is_subscribed_)
+  {
+    is_subscribed_ = false;
+  }
+}
+
+void BatteryConverter::registerCallback( message_actions::MessageAction action, Callback_t cb )
+{
+  callbacks_[action] = cb;
+}
+
+void BatteryConverter::callAll( const std::vector<message_actions::MessageAction>& actions )
+{
+  if (!is_subscribed_)
+  {
+    is_subscribed_ = true;
+  }
+
+  std::vector<float> values;
+  try {
+      qi::AnyValue anyvalues = p_memory_.call<qi::AnyValue>("getListData", keys_);
+      tools::fromAnyValueToFloatVector(anyvalues, values);
+  } catch (const std::exception& e) {
+    std::cerr << "Exception caught in BatteryConverter: " << e.what() << std::endl;
+    return;
+  }
+  
+  msg_.header.stamp = ros::Time::now();
+  msg_.charge = (int)(values[0] * 100.0);
+  msg_.voltage = values[1];
+  msg_.current = values[2];
+  msg_.hatch_open = (bool)values[3];
+  msg_.charging = ((int)values[4]) == 8;
+  msg_.connected_to_charging_station = (bool)values[5];
+
+  for_each( message_actions::MessageAction action, actions )
+  {
+    callbacks_[action]( msg_ );
+  }
+}
+
+void BatteryConverter::reset( )
+{
+  if (is_subscribed_)
+  {
+//    p_battery_.call<void>("unsubscribe", "ROS");
+    is_subscribed_ = false;
+  }
+}
+
+} // publisher
+} //naoqi

--- a/src/converters/battery.hpp
+++ b/src/converters/battery.hpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2015 Aldebaran
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef BATTERY_CONVERTER_HPP
+#define BATTERY_CONVERTER_HPP
+
+/*
+* LOCAL includes
+*/
+#include "converter_base.hpp"
+#include <naoqi_driver/message_actions.h>
+
+/*
+* ROS includes
+*/
+#include <nao_interaction_msgs/BatteryInfo.h>
+
+namespace naoqi
+{
+namespace converter
+{
+
+class BatteryConverter : public BaseConverter<BatteryConverter>
+{
+
+  typedef boost::function<void(nao_interaction_msgs::BatteryInfo&)> Callback_t;
+
+
+public:
+  BatteryConverter( const std::string& name, const float& frequency, const qi::SessionPtr& session );
+
+  ~BatteryConverter();
+
+  void reset( );
+
+  void registerCallback( message_actions::MessageAction action, Callback_t cb );
+
+  void callAll( const std::vector<message_actions::MessageAction>& actions );
+
+
+private:
+  std::map<message_actions::MessageAction, Callback_t> callbacks_;
+
+  /** Battery (Proxy) configurations */
+  qi::AnyObject p_battery_;
+  /** Memory (Proxy) configurations */
+  qi::AnyObject p_memory_;
+  /** Key describeing whether we are subscribed to the ALBattery module */
+  bool is_subscribed_;
+
+  /** The memory keys of the battery */
+  std::vector<std::string> keys_;
+  /** Pre-filled messges that are sent */
+  nao_interaction_msgs::BatteryInfo msg_;
+};
+
+} //publisher
+} //naoqi
+
+#endif

--- a/src/converters/camera_info_definitions.hpp
+++ b/src/converters/camera_info_definitions.hpp
@@ -60,14 +60,14 @@ inline sensor_msgs::CameraInfo createCameraInfoTOPQVGA()
 
   cam_info_msg.width = 320;
   cam_info_msg.height = 240;
-  cam_info_msg.K = boost::array<double, 9>{{ 274.139508945831, 0, 141.184472810944, 0, 275.741846757374, 106.693773654172, 0, 0, 1 }};
+  cam_info_msg.K = boost::array<double, 9>{{ 299.6062514048825, 0.0, 158.1342557533627, 0.0, 299.0567251221516, 128.32075058816002, 0.0, 0.0, 1.0 }};
 
   cam_info_msg.distortion_model = "plumb_bob";
-  cam_info_msg.D = boost::assign::list_of(-0.0870160932911717)(0.128210165050533)(0.003379500659424)(-0.00106205540818586)(0).convert_to_container<std::vector<double> >();
+  cam_info_msg.D = boost::assign::list_of(0.10703186895554358)(-0.29398440554631)(-0.000510763491296248)(-0.0007849727454197071)(0).convert_to_container<std::vector<double> >();
 
   cam_info_msg.R = boost::array<double, 9>{{ 1, 0, 0, 0, 1, 0, 0, 0, 1 }};
 
-  cam_info_msg.P = boost::array<double, 12>{{ 272.423675537109, 0, 141.131930791285, 0, 0, 273.515747070312, 107.391746054313, 0, 0, 0, 1, 0 }};
+  cam_info_msg.P = boost::array<double, 12>{{ 300.6907958984375, 0.0, 157.3720124539832, 0.0, 0.0, 300.78662109375, 127.71553373332426, 0.0, 0.0, 0.0, 1.0, 0.0 }};
 
   return cam_info_msg;
 }
@@ -173,8 +173,8 @@ inline sensor_msgs::CameraInfo createCameraInfoDEPTHVGA()
   cam_info_msg.height = 480;
   cam_info_msg.K = boost::array<double, 9>{{ 525, 0, 319.5000000, 0, 525, 239.5000000000000, 0, 0, 1  }};
 
-  //cam_info_msg.distortion_model = "plumb_bob";
-  //cam_info_msg.D = boost::assign::list_of(-0.0688388724945936)(0.0697453843669642)(0.00309518737071049)(-0.00570486993696543)(0);
+  cam_info_msg.distortion_model = "plumb_bob";
+  cam_info_msg.D = boost::assign::list_of(-0.0688388724945936)(0.0697453843669642)(0.00309518737071049)(-0.00570486993696543)(0);
 
   cam_info_msg.R = boost::array<double, 9>{{ 1, 0, 0, 0, 1, 0, 0, 0, 1 }};
 
@@ -192,14 +192,14 @@ inline sensor_msgs::CameraInfo createCameraInfoDEPTHQVGA()
 
   cam_info_msg.width = 320;
   cam_info_msg.height = 240;
-  cam_info_msg.K = boost::array<double, 9>{{ 525/2.0f, 0, 319.5000000/2.0f, 0, 525/2.0f, 239.5000000000000/2.0f, 0, 0, 1  }};
+  cam_info_msg.K = boost::array<double, 9>{{ 285.6768151355473, 0.0, 161.1691935721059, 0.0, 285.5373311462721, 127.602991640182, 0.0, 0.0, 1.0 }};
 
-  //cam_info_msg.distortion_model = "plumb_bob";
-  //cam_info_msg.D = boost::assign::list_of(-0.0688388724945936)(0.0697453843669642)(0.00309518737071049)(-0.00570486993696543)(0);
+  cam_info_msg.distortion_model = "plumb_bob";
+  cam_info_msg.D = boost::assign::list_of(0.016936081367960803)(-0.06749793149686571)(-0.0003138996585151219)(-0.0006992075603777127)(0);
 
   cam_info_msg.R = boost::array<double, 9>{{ 1, 0, 0, 0, 1, 0, 0, 0, 1 }};
 
-  cam_info_msg.P = boost::array<double, 12>{{ 525/2.0f, 0, 319.500000/2.0f, 0, 0, 525/2.0f, 239.5000000000/2.0f, 0, 0, 0, 1, 0 }};
+  cam_info_msg.P = boost::array<double, 12>{{ 284.4026794433594, 0.0, 160.49353466767207, 0.0, 0.0, 284.6112365722656, 127.04678797627457, 0.0, 0.0, 0.0, 1.0, 0.0 }};
 
   return cam_info_msg;
 }
@@ -214,8 +214,8 @@ inline sensor_msgs::CameraInfo createCameraInfoDEPTHQQVGA()
   cam_info_msg.height = 120;
   cam_info_msg.K = boost::array<double, 9>{{ 525/4.0f, 0, 319.5000000/4.0f, 0, 525/4.0f, 239.5000000000000/4.0f, 0, 0, 1  }};
 
-  //cam_info_msg.distortion_model = "plumb_bob";
-  //cam_info_msg.D = boost::assign::list_of(-0.0688388724945936)(0.0697453843669642)(0.00309518737071049)(-0.00570486993696543)(0);
+  cam_info_msg.distortion_model = "plumb_bob";
+  cam_info_msg.D = boost::assign::list_of(-0.0688388724945936)(0.0697453843669642)(0.00309518737071049)(-0.00570486993696543)(0);
 
   cam_info_msg.R = boost::array<double, 9>{{ 1, 0, 0, 0, 1, 0, 0, 0, 1 }};
 

--- a/src/converters/people.cpp
+++ b/src/converters/people.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2015 Aldebaran
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+/*
+* LOCAL includes
+*/
+#include "people.hpp"
+
+/*
+* BOOST includes
+*/
+#include <boost/foreach.hpp>
+#define for_each BOOST_FOREACH
+
+namespace naoqi{
+
+namespace converter{
+
+template <class T>
+PeopleEventConverter<T>::PeopleEventConverter(const std::string& name, const float& frequency, const qi::SessionPtr& session)
+  : BaseConverter<PeopleEventConverter<T> >(name, frequency, session)
+{
+}
+
+template <class T>
+PeopleEventConverter<T>::~PeopleEventConverter() {
+}
+
+template <class T>
+void PeopleEventConverter<T>::reset()
+{
+}
+
+template <class T>
+void PeopleEventConverter<T>::registerCallback( const message_actions::MessageAction action, Callback_t cb )
+{
+  callbacks_[action] = cb;
+}
+
+template <class T>
+void PeopleEventConverter<T>::callAll(const std::vector<message_actions::MessageAction>& actions, T& msg)
+{
+  msg_ = msg;
+  for_each( message_actions::MessageAction action, actions )
+  {
+    callbacks_[action](msg_);
+  }
+}
+
+// http://stackoverflow.com/questions/8752837/undefined-reference-to-template-class-constructor
+template class PeopleEventConverter<nao_interaction_msgs::FaceDetected>;
+}
+
+}

--- a/src/converters/people.cpp
+++ b/src/converters/people.cpp
@@ -62,8 +62,8 @@ void PeopleEventConverter<T>::callAll(const std::vector<message_actions::Message
 }
 
 // http://stackoverflow.com/questions/8752837/undefined-reference-to-template-class-constructor
-template class PeopleEventConverter<nao_interaction_msgs::FacesDetected>;
-template class PeopleEventConverter<nao_interaction_msgs::PersonCharacteristicsArray>;
+template class PeopleEventConverter<nao_interaction_msgs::FaceDetectedArray>;
+template class PeopleEventConverter<nao_interaction_msgs::PersonDetectedArray>;
 }
 
 }

--- a/src/converters/people.cpp
+++ b/src/converters/people.cpp
@@ -63,7 +63,7 @@ void PeopleEventConverter<T>::callAll(const std::vector<message_actions::Message
 
 // http://stackoverflow.com/questions/8752837/undefined-reference-to-template-class-constructor
 template class PeopleEventConverter<nao_interaction_msgs::FacesDetected>;
-template class PeopleEventConverter<geometry_msgs::PoseArray>;
+template class PeopleEventConverter<nao_interaction_msgs::PersonCharacteristicsArray>;
 }
 
 }

--- a/src/converters/people.cpp
+++ b/src/converters/people.cpp
@@ -62,7 +62,8 @@ void PeopleEventConverter<T>::callAll(const std::vector<message_actions::Message
 }
 
 // http://stackoverflow.com/questions/8752837/undefined-reference-to-template-class-constructor
-template class PeopleEventConverter<nao_interaction_msgs::FaceDetected>;
+template class PeopleEventConverter<nao_interaction_msgs::FacesDetected>;
+template class PeopleEventConverter<geometry_msgs::PoseArray>;
 }
 
 }

--- a/src/converters/people.hpp
+++ b/src/converters/people.hpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2015 Aldebaran
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef PEOPLE_EVENT_CONVERTER_HPP
+#define PEOPLE_EVENT_CONVERTER_HPP
+
+/*
+* LOCAL includes
+*/
+#include "converter_base.hpp"
+#include <naoqi_driver/message_actions.h>
+
+/*
+* ROS includes
+*/
+#include <nao_interaction_msgs/FaceDetected.h>
+
+/*
+* ALDEBARAN includes
+*/
+#include <qi/anymodule.hpp>
+
+namespace naoqi{
+
+namespace converter{
+
+template <class T>
+class PeopleEventConverter : public BaseConverter<PeopleEventConverter<T> >
+{
+
+  typedef boost::function<void(T&) > Callback_t;
+
+public:
+  PeopleEventConverter(const std::string& name, const float& frequency, const qi::SessionPtr& session);
+
+  ~PeopleEventConverter();
+
+  virtual void reset();
+
+  void registerCallback( const message_actions::MessageAction action, Callback_t cb );
+
+  void callAll(const std::vector<message_actions::MessageAction>& actions, T& msg);
+
+private:
+  /** Registered Callbacks **/
+  std::map<message_actions::MessageAction, Callback_t> callbacks_;
+  T msg_;
+};
+
+}
+
+}
+
+#endif // PEOPLE_CONVERTER_HPP

--- a/src/converters/people.hpp
+++ b/src/converters/people.hpp
@@ -27,8 +27,8 @@
 /*
 * ROS includes
 */
-#include <nao_interaction_msgs/FacesDetected.h>
-#include <nao_interaction_msgs/PersonCharacteristicsArray.h>
+#include <nao_interaction_msgs/FaceDetectedArray.h>
+#include <nao_interaction_msgs/PersonDetectedArray.h>
 /*
 * ALDEBARAN includes
 */

--- a/src/converters/people.hpp
+++ b/src/converters/people.hpp
@@ -28,9 +28,7 @@
 * ROS includes
 */
 #include <nao_interaction_msgs/FacesDetected.h>
-#include <geometry_msgs/PoseArray.h>
-#include <geometry_msgs/Pose.h>
-
+#include <nao_interaction_msgs/PersonCharacteristicsArray.h>
 /*
 * ALDEBARAN includes
 */

--- a/src/converters/people.hpp
+++ b/src/converters/people.hpp
@@ -27,7 +27,9 @@
 /*
 * ROS includes
 */
-#include <nao_interaction_msgs/FaceDetected.h>
+#include <nao_interaction_msgs/FacesDetected.h>
+#include <geometry_msgs/PoseArray.h>
+#include <geometry_msgs/Pose.h>
 
 /*
 * ALDEBARAN includes

--- a/src/converters/sound.cpp
+++ b/src/converters/sound.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2015 Aldebaran
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+/*
+* LOCAL includes
+*/
+#include "sound.hpp"
+
+/*
+* BOOST includes
+*/
+#include <boost/foreach.hpp>
+#define for_each BOOST_FOREACH
+
+namespace naoqi{
+
+namespace converter{
+
+template <class T>
+SoundEventConverter<T>::SoundEventConverter(const std::string& name, const float& frequency, const qi::SessionPtr& session)
+  : BaseConverter<SoundEventConverter<T> >(name, frequency, session)
+{
+}
+
+template <class T>
+SoundEventConverter<T>::~SoundEventConverter() {
+}
+
+template <class T>
+void SoundEventConverter<T>::reset()
+{
+}
+
+template <class T>
+void SoundEventConverter<T>::registerCallback( const message_actions::MessageAction action, Callback_t cb )
+{
+  callbacks_[action] = cb;
+}
+
+template <class T>
+void SoundEventConverter<T>::callAll(const std::vector<message_actions::MessageAction>& actions, T& msg)
+{
+  msg_ = msg;
+  for_each( message_actions::MessageAction action, actions )
+  {
+    callbacks_[action](msg_);
+  }
+}
+
+// http://stackoverflow.com/questions/8752837/undefined-reference-to-template-class-constructor
+template class SoundEventConverter<nao_interaction_msgs::AudioSourceLocalization>;
+}
+
+}

--- a/src/converters/sound.hpp
+++ b/src/converters/sound.hpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2015 Aldebaran
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef SOUND_EVENT_CONVERTER_HPP
+#define SOUND_EVENT_CONVERTER_HPP
+
+/*
+* LOCAL includes
+*/
+#include "converter_base.hpp"
+#include <naoqi_driver/message_actions.h>
+
+/*
+* ROS includes
+*/
+#include <nao_interaction_msgs/AudioSourceLocalization.h>
+/*
+* ALDEBARAN includes
+*/
+#include <qi/anymodule.hpp>
+
+namespace naoqi{
+
+namespace converter{
+
+template <class T>
+class SoundEventConverter : public BaseConverter<SoundEventConverter<T> >
+{
+
+  typedef boost::function<void(T&) > Callback_t;
+
+public:
+  SoundEventConverter(const std::string& name, const float& frequency, const qi::SessionPtr& session);
+
+  ~SoundEventConverter();
+
+  virtual void reset();
+
+  void registerCallback( const message_actions::MessageAction action, Callback_t cb );
+
+  void callAll(const std::vector<message_actions::MessageAction>& actions, T& msg);
+
+private:
+  /** Registered Callbacks **/
+  std::map<message_actions::MessageAction, Callback_t> callbacks_;
+  T msg_;
+};
+
+}
+
+}
+
+#endif // PEOPLE_CONVERTER_HPP

--- a/src/event/people.cpp
+++ b/src/event/people.cpp
@@ -1,0 +1,263 @@
+/*
+ * Copyright 2015 Aldebaran
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <iostream>
+#include <vector>
+
+#include <boost/make_shared.hpp>
+
+#include <ros/ros.h>
+
+#include <qi/anyobject.hpp>
+
+#include <naoqi_driver/recorder/globalrecorder.hpp>
+#include <naoqi_driver/message_actions.h>
+#include "../tools/from_any_value.hpp"
+
+#include "people.hpp"
+
+namespace naoqi
+{
+
+template<class T>
+PeopleEventRegister<T>::PeopleEventRegister()
+{
+}
+
+template<class T>
+PeopleEventRegister<T>::PeopleEventRegister( const std::string& name, const std::vector<std::string> keys, const float& frequency, const qi::SessionPtr& session )
+  : serviceId(0),
+    p_memory_( session->service("ALMemory")),
+    session_(session),
+    isStarted_(false),
+    isPublishing_(false),
+    isRecording_(false),
+    isDumping_(false)
+{
+  publisher_ = boost::make_shared<publisher::BasicPublisher<T> >( name );
+  //recorder_ = boost::make_shared<recorder::BasicEventRecorder<T> >( name );
+  converter_ = boost::make_shared<converter::PeopleEventConverter<T> >( name, frequency, session );
+
+  converter_->registerCallback( message_actions::PUBLISH, boost::bind(&publisher::BasicPublisher<T>::publish, publisher_, _1) );
+  //converter_->registerCallback( message_actions::RECORD, boost::bind(&recorder::BasicEventRecorder<T>::write, recorder_, _1) );
+  //converter_->registerCallback( message_actions::LOG, boost::bind(&recorder::BasicEventRecorder<T>::bufferize, recorder_, _1) );
+
+  keys_.resize(keys.size());
+  size_t i = 0;
+  for(std::vector<std::string>::const_iterator it = keys.begin(); it != keys.end(); ++it, ++i)
+    keys_[i] = *it;
+
+  name_ = name;
+}
+
+template<class T>
+PeopleEventRegister<T>::~PeopleEventRegister()
+{
+  stopProcess();
+}
+
+template<class T>
+void PeopleEventRegister<T>::resetPublisher(ros::NodeHandle& nh)
+{
+  publisher_->reset(nh);
+}
+
+template<class T>
+void PeopleEventRegister<T>::resetRecorder( boost::shared_ptr<naoqi::recorder::GlobalRecorder> gr )
+{
+  //recorder_->reset(gr, converter_->frequency());
+}
+
+template<class T>
+void PeopleEventRegister<T>::startProcess()
+{
+  boost::mutex::scoped_lock start_lock(mutex_);
+  if (!isStarted_)
+  {
+    if(!serviceId)
+    {
+      //std::string serviceName = std::string("ROS-Driver-") + typeid(T).name();
+      std::string serviceName = std::string("ROS-Driver-") + keys_[0];
+      serviceId = session_->registerService(serviceName, this->shared_from_this());
+      for(std::vector<std::string>::const_iterator it = keys_.begin(); it != keys_.end(); ++it) {
+        std::cerr << *it << std::endl;
+        p_memory_.call<void>("subscribeToEvent",it->c_str(), serviceName, "peopleCallback");
+      }
+      std::cout << serviceName << " : Start" << std::endl;
+    }
+    isStarted_ = true;
+  }
+}
+
+template<class T>
+void PeopleEventRegister<T>::stopProcess()
+{
+  boost::mutex::scoped_lock stop_lock(mutex_);
+  if (isStarted_)
+  {
+    //std::string serviceName = std::string("ROS-Driver-") + typeid(T).name();
+    std::string serviceName = std::string("ROS-Driver-") + keys_[0];
+    if(serviceId){
+      p_memory_.call<void>("unsubscribeToEvent", serviceName, "peopleCallback");
+      session_->unregisterService(serviceId);
+      serviceId = 0;
+    }
+    std::cout << serviceName << " : Stop" << std::endl;
+    isStarted_ = false;
+  }
+}
+
+template<class T>
+void PeopleEventRegister<T>::writeDump(const ros::Time& time)
+{
+  if (isStarted_)
+  {
+    //recorder_->writeDump(time);
+  }
+}
+
+template<class T>
+void PeopleEventRegister<T>::setBufferDuration(float duration)
+{
+  //recorder_->setBufferDuration(duration);
+}
+
+template<class T>
+void PeopleEventRegister<T>::isRecording(bool state)
+{
+  boost::mutex::scoped_lock rec_lock(mutex_);
+  isRecording_ = state;
+}
+
+template<class T>
+void PeopleEventRegister<T>::isPublishing(bool state)
+{
+  boost::mutex::scoped_lock pub_lock(mutex_);
+  isPublishing_ = state;
+}
+
+template<class T>
+void PeopleEventRegister<T>::isDumping(bool state)
+{
+  boost::mutex::scoped_lock dump_lock(mutex_);
+  isDumping_ = state;
+}
+
+template<class T>
+void PeopleEventRegister<T>::registerCallback()
+{
+}
+
+template<class T>
+void PeopleEventRegister<T>::unregisterCallback()
+{
+}
+
+template<class T>
+void PeopleEventRegister<T>::peopleCallback(std::string &key, qi::AnyValue &value, qi::AnyValue &message)
+{
+  T msg = T();
+  
+  tools::NaoqiFaceDetected faces;
+  try {
+    faces = tools::fromAnyValueToNaoqiFaceDetected(value);
+  }
+  catch(std::runtime_error& e)
+  {
+    std::cout << "Cannot retrieve facedetect" << std::endl;
+    return;
+  }
+
+  if ( faces.face_info.size() > 0 ) { // sometimes value does not have face information..
+    peopleCallbackMessage(key, faces, msg);
+  }
+
+  std::vector<message_actions::MessageAction> actions;
+  boost::mutex::scoped_lock callback_lock(mutex_);
+
+  if (isStarted_) {
+    // CHECK FOR PUBLISH
+    if ( isPublishing_ && publisher_->isSubscribed() )
+    {
+      actions.push_back(message_actions::PUBLISH);
+    }
+    // CHECK FOR RECORD
+    if ( isRecording_ )
+    {
+      //actions.push_back(message_actions::RECORD);
+    }
+    if ( !isDumping_ )
+    {
+      //actions.push_back(message_actions::LOG);
+    }
+    if (actions.size() >0)
+    {
+      converter_->callAll( actions, msg );
+    }
+  }
+}
+
+template<class T>
+void PeopleEventRegister<T>::peopleCallbackMessage(std::string &key, tools::NaoqiFaceDetected &faces, nao_interaction_msgs::FaceDetected &msg)
+{
+  msg.header.frame_id = "";
+  msg.header.stamp = ros::Time(faces.timestamp.timestamp_s, faces.timestamp.timestamp_us);
+
+  if ( faces.face_info.size() > 0 ) {
+    msg.face_id.data = faces.face_info[0].extra_info[0].face_id;
+    msg.score_reco.data = faces.face_info[0].extra_info[0].score_reco;
+    msg.face_label.data = faces.face_info[0].extra_info[0].face_label;
+
+    msg.shape_alpha.data = faces.face_info[0].shape_info.alpha;
+    msg.shape_beta.data  = faces.face_info[0].shape_info.beta;
+    msg.shape_sizeX.data = faces.face_info[0].shape_info.sizeX;
+    msg.shape_sizeY.data = faces.face_info[0].shape_info.sizeY;
+
+    msg.right_eye_eyeCenter_x.data = faces.face_info[0].extra_info[0].right_eye_points.eye_center_x;
+    msg.right_eye_eyeCenter_y.data = faces.face_info[0].extra_info[0].right_eye_points.eye_center_y;
+    msg.right_eye_noseSideLimit_x.data = faces.face_info[0].extra_info[0].right_eye_points.nose_side_limit_x;
+    msg.right_eye_noseSideLimit_y.data = faces.face_info[0].extra_info[0].right_eye_points.nose_side_limit_y;
+    msg.right_eye_earSideLimit_x.data = faces.face_info[0].extra_info[0].right_eye_points.ear_side_limit_x;
+    msg.right_eye_earSideLimit_y.data = faces.face_info[0].extra_info[0].right_eye_points.ear_side_limit_y;
+
+    msg.left_eye_eyeCenter_x.data = faces.face_info[0].extra_info[0].left_eye_points.eye_center_x;
+    msg.left_eye_eyeCenter_y.data = faces.face_info[0].extra_info[0].left_eye_points.eye_center_y;
+    msg.left_eye_noseSideLimit_x.data = faces.face_info[0].extra_info[0].left_eye_points.nose_side_limit_x;
+    msg.left_eye_noseSideLimit_y.data = faces.face_info[0].extra_info[0].left_eye_points.nose_side_limit_y;
+    msg.left_eye_earSideLimit_x.data = faces.face_info[0].extra_info[0].left_eye_points.ear_side_limit_x;
+    msg.left_eye_earSideLimit_y.data = faces.face_info[0].extra_info[0].left_eye_points.ear_side_limit_y;
+
+    msg.nose_bottomCenterLimit_x.data = faces.face_info[0].extra_info[0].nose_points.bottom_center_limit_x;
+    msg.nose_bottomCenterLimit_y.data = faces.face_info[0].extra_info[0].nose_points.bottom_center_limit_y;
+    msg.nose_bottomLeftLimit_x.data = faces.face_info[0].extra_info[0].nose_points.bottom_left_limit_x;
+    msg.nose_bottomLeftLimit_y.data = faces.face_info[0].extra_info[0].nose_points.bottom_left_limit_y;
+    msg.nose_bottomRightLimit_x.data = faces.face_info[0].extra_info[0].nose_points.bottom_right_limit_x;
+    msg.nose_bottomRightLimit_y.data = faces.face_info[0].extra_info[0].nose_points.bottom_right_limit_y;
+
+    msg.mouth_leftLimit_x.data = faces.face_info[0].extra_info[0].mouth_points.left_limit_x;
+    msg.mouth_leftLimit_y.data = faces.face_info[0].extra_info[0].mouth_points.left_limit_y;
+    msg.mouth_rightLimit_x.data = faces.face_info[0].extra_info[0].mouth_points.right_limit_x;
+    msg.mouth_rightLimit_y.data = faces.face_info[0].extra_info[0].mouth_points.right_limit_y;
+    msg.mouth_topLimit_x.data = faces.face_info[0].extra_info[0].mouth_points.top_limit_x;
+    msg.mouth_topLimit_y.data = faces.face_info[0].extra_info[0].mouth_points.top_limit_y;
+  }
+}
+
+// http://stackoverflow.com/questions/8752837/undefined-reference-to-template-class-constructor
+template class PeopleEventRegister<nao_interaction_msgs::FaceDetected>;
+
+}//namespace

--- a/src/event/people.cpp
+++ b/src/event/people.cpp
@@ -247,7 +247,7 @@ void PeopleEventRegister<T>::peopleCallbackMessage(std::string &key, qi::AnyValu
   }
   catch(std::runtime_error& e)
   {
-    std::cout << "Cannot retrieve facedetect" << std::endl;
+    ROS_DEBUG_STREAM("Cannot retrieve facedetect: " << e.what());
     return;
   }
   if ( faces.face_info.size() == 0 ) return;
@@ -317,7 +317,7 @@ void PeopleEventRegister<T>::peopleCallbackMessage(std::string &key, qi::AnyValu
     }
     catch(std::runtime_error& e)
     {
-      std::cout << "Cannot retrieve persondetected: " << e.what() << std::endl;
+      ROS_DEBUG_STREAM("Cannot retrieve persondetected: " << e.what());
       return;
     }
     
@@ -360,7 +360,7 @@ void PeopleEventRegister<T>::peopleCallbackMessage(std::string &key, qi::AnyValu
             try {
                 pd.person.is_waving = (bool)data[1].content().asInt32();
             } catch(...) {
-                ROS_INFO("Error retreiving if waving");
+                ROS_DEBUG("Error retreiving if waving");
             }
             
             if(pd.person.face_detected) {

--- a/src/event/people.cpp
+++ b/src/event/people.cpp
@@ -235,7 +235,6 @@ void PeopleEventRegister<T>::peopleCallback(std::string &key, qi::AnyValue &valu
 template<class T>
 void PeopleEventRegister<T>::peopleCallbackMessage(std::string &key, qi::AnyValue &value, nao_interaction_msgs::FaceDetectedArray &msg)
 {
-    std::cout<<"THERE"<<std::endl;
   tools::NaoqiFaceDetected faces;
   try {
     faces = tools::fromAnyValueToNaoqiFaceDetected(value);
@@ -248,7 +247,7 @@ void PeopleEventRegister<T>::peopleCallbackMessage(std::string &key, qi::AnyValu
   if ( faces.face_info.size() == 0 ) return;
   
   msg.header.frame_id = "CameraTop_optical_frame";
-  msg.header.stamp = ros::Time::now(); // ros::Time(faces.timestamp.timestamp_s, faces.timestamp.timestamp_us); // This gives time till start not the system time
+  msg.header.stamp = ros::Time::now();
 
   for(int i = 0; i < faces.face_info.size(); i++) {
     nao_interaction_msgs::FaceDetected face;
@@ -306,7 +305,6 @@ geometry_msgs::Point PeopleEventRegister<T>::toCartesian(float dist, float azi, 
 template<class T>
 void PeopleEventRegister<T>::peopleCallbackMessage(std::string &key, qi::AnyValue &value, nao_interaction_msgs::PersonDetectedArray &msg)
 {
-    std::cout<<"HERE"<<std::endl;
     tools::NaoqiPersonDetected people;
     try {
         people = tools::fromAnyValueToNaoqiPersonDetected(value);
@@ -318,7 +316,7 @@ void PeopleEventRegister<T>::peopleCallbackMessage(std::string &key, qi::AnyValu
     }
     
     msg.header.frame_id = "CameraDepth_optical_frame";
-    msg.header.stamp = ros::Time::now(); //ros::Time(people.timestamp.timestamp_s, people.timestamp.timestamp_us); // This gives time till start not the system time
+    msg.header.stamp = ros::Time::now();
     
     for(int i = 0; i < people.person_info.size(); i++) {
         std::string sid = num_to_str<int>(people.person_info[i].id);
@@ -500,7 +498,6 @@ void PeopleEventRegister<T>::peopleCallbackMessage(std::string &key, qi::AnyValu
         } catch(std::runtime_error& e) {
             ROS_DEBUG_STREAM("Error retrieving person information: " << e.what());
         }
-        
         
         msg.person_array.push_back(pd);
     }

--- a/src/event/people.hpp
+++ b/src/event/people.hpp
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2015 Aldebaran
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef PEOPLE_EVENT_REGISTER_HPP
+#define PEOPLE_EVENT_REGISTER_HPP
+
+#include <string>
+
+#include <boost/make_shared.hpp>
+#include <boost/shared_ptr.hpp>
+#include <boost/thread/mutex.hpp>
+#include <boost/enable_shared_from_this.hpp>
+
+#include <qi/session.hpp>
+
+#include <ros/ros.h>
+#include <nao_interaction_msgs/FaceDetected.h>
+
+#include <naoqi_driver/tools.hpp>
+#include <naoqi_driver/recorder/globalrecorder.hpp>
+
+#include "../tools/naoqi_facedetected.hpp"
+
+// Converter
+#include "../src/converters/people.hpp"
+// Publisher
+#include "../src/publishers/basic.hpp"
+// Recorder
+#include "../recorder/basic_event.hpp"
+
+namespace naoqi
+{
+
+/**
+* @brief GlobalRecorder concept interface
+* @note this defines an private concept struct,
+* which each instance has to implement
+* @note a type erasure pattern in implemented here to avoid strict inheritance,
+* thus each possible publisher instance has to implement the virtual functions mentioned in the concept
+*/
+template<class T>
+class PeopleEventRegister: public boost::enable_shared_from_this<PeopleEventRegister<T> >
+{
+
+public:
+
+  /**
+  * @brief Constructor for recorder interface
+  */
+  PeopleEventRegister();
+  PeopleEventRegister(const std::string& name, const std::vector<std::string> keys, const float& frequency, const qi::SessionPtr& session );
+  ~PeopleEventRegister();
+
+  void resetPublisher( ros::NodeHandle& nh );
+  void resetRecorder( boost::shared_ptr<naoqi::recorder::GlobalRecorder> gr );
+
+  void startProcess();
+  void stopProcess();
+
+  void writeDump(const ros::Time& time);
+  void setBufferDuration(float duration);
+
+  void isRecording(bool state);
+  void isPublishing(bool state);
+  void isDumping(bool state);
+
+  void peopleCallback(std::string &key, qi::AnyValue &value, qi::AnyValue &message);
+  void peopleCallbackMessage(std::string &key, tools::NaoqiFaceDetected &faces, nao_interaction_msgs::FaceDetected &msg);
+  
+
+private:
+  void registerCallback();
+  void unregisterCallback();
+  void onEvent();
+
+private:
+  boost::shared_ptr<converter::PeopleEventConverter<T> > converter_;
+  boost::shared_ptr<publisher::BasicPublisher<T> > publisher_;
+  //boost::shared_ptr<recorder::BasicEventRecorder<T> > recorder_;
+
+  qi::SessionPtr session_;
+  qi::AnyObject p_memory_;
+  unsigned int serviceId;
+  std::string name_;
+
+  boost::mutex mutex_;
+
+  bool isStarted_;
+  bool isPublishing_;
+  bool isRecording_;
+  bool isDumping_;
+
+protected:
+  std::vector<std::string> keys_;
+}; // class
+
+
+class FaceDetectedEventRegister: public PeopleEventRegister<nao_interaction_msgs::FaceDetected>
+{
+public:
+  FaceDetectedEventRegister( const std::string& name, const std::vector<std::string> keys, const float& frequency, const qi::SessionPtr& session ) : PeopleEventRegister<nao_interaction_msgs::FaceDetected>(name, keys, frequency, session) {}
+};
+
+//QI_REGISTER_OBJECT(FaceDetectEventRegister, peopleCallback)
+
+static bool _qiregisterPeopleEventRegisterFaceDetected() {
+  ::qi::ObjectTypeBuilder<PeopleEventRegister<nao_interaction_msgs::FaceDetected> > b;
+  QI_VAARGS_APPLY(__QI_REGISTER_ELEMENT, PeopleEventRegister<nao_interaction_msgs::FaceDetected>, peopleCallback)
+    b.registerType();
+  return true;
+  }
+static bool BOOST_PP_CAT(__qi_registration, __LINE__) = _qiregisterPeopleEventRegisterFaceDetected();
+
+} //naoqi
+
+#endif

--- a/src/event/people.hpp
+++ b/src/event/people.hpp
@@ -29,9 +29,8 @@
 #include <qi/session.hpp>
 
 #include <ros/ros.h>
-#include <nao_interaction_msgs/FaceDetected.h>
-#include <nao_interaction_msgs/FacesDetected.h>
-#include <nao_interaction_msgs/PersonCharacteristicsArray.h>
+#include <nao_interaction_msgs/FaceDetectedArray.h>
+#include <nao_interaction_msgs/PersonDetectedArray.h>
 #include <tf/transform_datatypes.h>
 
 #include <naoqi_driver/tools.hpp>
@@ -83,8 +82,8 @@ public:
   void isDumping(bool state);
 
   void peopleCallback(std::string &key, qi::AnyValue &value, qi::AnyValue &message);
-  void peopleCallbackMessage(std::string &key, qi::AnyValue &value, nao_interaction_msgs::FacesDetected &msg);
-  void peopleCallbackMessage(std::string &key, qi::AnyValue &value, nao_interaction_msgs::PersonCharacteristicsArray &msg);
+  void peopleCallbackMessage(std::string &key, qi::AnyValue &value, nao_interaction_msgs::FaceDetectedArray &msg);
+  void peopleCallbackMessage(std::string &key, qi::AnyValue &value, nao_interaction_msgs::PersonDetectedArray &msg);
 
 private:
   void registerCallback();
@@ -123,32 +122,32 @@ protected:
 }; // class
 
 
-class FaceDetectedEventRegister: public PeopleEventRegister<nao_interaction_msgs::FacesDetected>
+class FaceDetectedEventRegister: public PeopleEventRegister<nao_interaction_msgs::FaceDetectedArray>
 {
 public:
-  FaceDetectedEventRegister( const std::string& name, const std::vector<std::string> keys, const float& frequency, const qi::SessionPtr& session ) : PeopleEventRegister<nao_interaction_msgs::FacesDetected>(name, keys, frequency, session) {}
+  FaceDetectedEventRegister( const std::string& name, const std::vector<std::string> keys, const float& frequency, const qi::SessionPtr& session ) : PeopleEventRegister<nao_interaction_msgs::FaceDetectedArray>(name, keys, frequency, session) {}
 };
 
-class PersonCharacteristicsEventRegister: public PeopleEventRegister<nao_interaction_msgs::PersonCharacteristicsArray>
+class PersonCharacteristicsEventRegister: public PeopleEventRegister<nao_interaction_msgs::PersonDetectedArray>
 {
 public:
-  PersonCharacteristicsEventRegister( const std::string& name, const std::vector<std::string> keys, const float& frequency, const qi::SessionPtr& session ) : PeopleEventRegister<nao_interaction_msgs::PersonCharacteristicsArray>(name, keys, frequency, session) {}
+  PersonCharacteristicsEventRegister( const std::string& name, const std::vector<std::string> keys, const float& frequency, const qi::SessionPtr& session ) : PeopleEventRegister<nao_interaction_msgs::PersonDetectedArray>(name, keys, frequency, session) {}
 };
 
 //QI_REGISTER_OBJECT(FaceDetectEventRegister, peopleCallback)
 //QI_REGISTER_OBJECT(PersonCharacteristicsEventRegister, peopleCallback)
 
 static bool _qiregisterPeopleEventRegisterFaceDetected() {
-  ::qi::ObjectTypeBuilder<PeopleEventRegister<nao_interaction_msgs::FacesDetected> > b;
-  QI_VAARGS_APPLY(__QI_REGISTER_ELEMENT, PeopleEventRegister<nao_interaction_msgs::FacesDetected>, peopleCallback)
+  ::qi::ObjectTypeBuilder<PeopleEventRegister<nao_interaction_msgs::FaceDetectedArray> > b;
+  QI_VAARGS_APPLY(__QI_REGISTER_ELEMENT, PeopleEventRegister<nao_interaction_msgs::FaceDetectedArray>, peopleCallback)
     b.registerType();
   return true;
   }
 static bool BOOST_PP_CAT(__qi_registration, __LINE__) = _qiregisterPeopleEventRegisterFaceDetected();
 
 static bool _qiregisterPeopleEventRegisterPersonCharacteristics() {
-  ::qi::ObjectTypeBuilder<PeopleEventRegister<nao_interaction_msgs::PersonCharacteristicsArray> > b;
-  QI_VAARGS_APPLY(__QI_REGISTER_ELEMENT, PeopleEventRegister<nao_interaction_msgs::PersonCharacteristicsArray>, peopleCallback)
+  ::qi::ObjectTypeBuilder<PeopleEventRegister<nao_interaction_msgs::PersonDetectedArray> > b;
+  QI_VAARGS_APPLY(__QI_REGISTER_ELEMENT, PeopleEventRegister<nao_interaction_msgs::PersonDetectedArray>, peopleCallback)
     b.registerType();
   return true;
   }

--- a/src/event/people.hpp
+++ b/src/event/people.hpp
@@ -31,8 +31,8 @@
 #include <ros/ros.h>
 #include <nao_interaction_msgs/FaceDetected.h>
 #include <nao_interaction_msgs/FacesDetected.h>
-#include <geometry_msgs/PoseArray.h>
-#include <geometry_msgs/Pose.h>
+#include <nao_interaction_msgs/PersonCharacteristicsArray.h>
+#include <tf/transform_datatypes.h>
 
 #include <naoqi_driver/tools.hpp>
 #include <naoqi_driver/recorder/globalrecorder.hpp>
@@ -84,13 +84,19 @@ public:
 
   void peopleCallback(std::string &key, qi::AnyValue &value, qi::AnyValue &message);
   void peopleCallbackMessage(std::string &key, qi::AnyValue &value, nao_interaction_msgs::FacesDetected &msg);
-  void peopleCallbackMessage(std::string &key, qi::AnyValue &value, geometry_msgs::PoseArray &msg);
+  void peopleCallbackMessage(std::string &key, qi::AnyValue &value, nao_interaction_msgs::PersonCharacteristicsArray &msg);
 
 private:
   void registerCallback();
   void unregisterCallback();
   void onEvent();
   geometry_msgs::Point toCartesian(float dist, float azi, float inc);
+  template<typename N>
+      std::string num_to_str(N num) {
+          std::stringstream ss;
+          ss << num;
+          return ss.str();
+      }
 
 private:
   boost::shared_ptr<converter::PeopleEventConverter<T> > converter_;
@@ -98,7 +104,7 @@ private:
   //boost::shared_ptr<recorder::BasicEventRecorder<T> > recorder_;
 
   qi::SessionPtr session_;
-  qi::AnyObject p_memory_;
+  qi::AnyObject p_memory_, p_people_, p_gaze_, p_face_;
   unsigned int serviceId;
   std::string name_;
 
@@ -109,7 +115,8 @@ private:
   bool isRecording_;
   bool isDumping_;
   
-  ros::Publisher p;
+  std::string prefix;
+  std::vector<std::string> memory_keys;
 
 protected:
   std::vector<std::string> keys_;
@@ -122,14 +129,14 @@ public:
   FaceDetectedEventRegister( const std::string& name, const std::vector<std::string> keys, const float& frequency, const qi::SessionPtr& session ) : PeopleEventRegister<nao_interaction_msgs::FacesDetected>(name, keys, frequency, session) {}
 };
 
-class PersonDetectedEventRegister: public PeopleEventRegister<geometry_msgs::PoseArray>
+class PersonCharacteristicsEventRegister: public PeopleEventRegister<nao_interaction_msgs::PersonCharacteristicsArray>
 {
 public:
-  PersonDetectedEventRegister( const std::string& name, const std::vector<std::string> keys, const float& frequency, const qi::SessionPtr& session ) : PeopleEventRegister<geometry_msgs::PoseArray>(name, keys, frequency, session) {}
+  PersonCharacteristicsEventRegister( const std::string& name, const std::vector<std::string> keys, const float& frequency, const qi::SessionPtr& session ) : PeopleEventRegister<nao_interaction_msgs::PersonCharacteristicsArray>(name, keys, frequency, session) {}
 };
 
 //QI_REGISTER_OBJECT(FaceDetectEventRegister, peopleCallback)
-//QI_REGISTER_OBJECT(PersonDetectedEventRegister, peopleCallback)
+//QI_REGISTER_OBJECT(PersonCharacteristicsEventRegister, peopleCallback)
 
 static bool _qiregisterPeopleEventRegisterFaceDetected() {
   ::qi::ObjectTypeBuilder<PeopleEventRegister<nao_interaction_msgs::FacesDetected> > b;
@@ -139,13 +146,13 @@ static bool _qiregisterPeopleEventRegisterFaceDetected() {
   }
 static bool BOOST_PP_CAT(__qi_registration, __LINE__) = _qiregisterPeopleEventRegisterFaceDetected();
 
-static bool _qiregisterPeopleEventRegisterPersonDetected() {
-  ::qi::ObjectTypeBuilder<PeopleEventRegister<geometry_msgs::PoseArray> > b;
-  QI_VAARGS_APPLY(__QI_REGISTER_ELEMENT, PeopleEventRegister<geometry_msgs::PoseArray>, peopleCallback)
+static bool _qiregisterPeopleEventRegisterPersonCharacteristics() {
+  ::qi::ObjectTypeBuilder<PeopleEventRegister<nao_interaction_msgs::PersonCharacteristicsArray> > b;
+  QI_VAARGS_APPLY(__QI_REGISTER_ELEMENT, PeopleEventRegister<nao_interaction_msgs::PersonCharacteristicsArray>, peopleCallback)
     b.registerType();
   return true;
   }
-static bool BOOST_PP_CAT(__qi_registration, __LINE__) = _qiregisterPeopleEventRegisterPersonDetected();
+static bool BOOST_PP_CAT(__qi_registration, __LINE__) = _qiregisterPeopleEventRegisterPersonCharacteristics();
 
 } //naoqi
 

--- a/src/event/people.hpp
+++ b/src/event/people.hpp
@@ -128,14 +128,14 @@ public:
   FaceDetectedEventRegister( const std::string& name, const std::vector<std::string> keys, const float& frequency, const qi::SessionPtr& session ) : PeopleEventRegister<nao_interaction_msgs::FaceDetectedArray>(name, keys, frequency, session) {}
 };
 
-class PersonCharacteristicsEventRegister: public PeopleEventRegister<nao_interaction_msgs::PersonDetectedArray>
+class PersonDetectedEventRegister: public PeopleEventRegister<nao_interaction_msgs::PersonDetectedArray>
 {
 public:
-  PersonCharacteristicsEventRegister( const std::string& name, const std::vector<std::string> keys, const float& frequency, const qi::SessionPtr& session ) : PeopleEventRegister<nao_interaction_msgs::PersonDetectedArray>(name, keys, frequency, session) {}
+  PersonDetectedEventRegister( const std::string& name, const std::vector<std::string> keys, const float& frequency, const qi::SessionPtr& session ) : PeopleEventRegister<nao_interaction_msgs::PersonDetectedArray>(name, keys, frequency, session) {}
 };
 
 //QI_REGISTER_OBJECT(FaceDetectEventRegister, peopleCallback)
-//QI_REGISTER_OBJECT(PersonCharacteristicsEventRegister, peopleCallback)
+//QI_REGISTER_OBJECT(PersonDetectedEventRegister, peopleCallback)
 
 static bool _qiregisterPeopleEventRegisterFaceDetected() {
   ::qi::ObjectTypeBuilder<PeopleEventRegister<nao_interaction_msgs::FaceDetectedArray> > b;
@@ -145,13 +145,13 @@ static bool _qiregisterPeopleEventRegisterFaceDetected() {
   }
 static bool BOOST_PP_CAT(__qi_registration, __LINE__) = _qiregisterPeopleEventRegisterFaceDetected();
 
-static bool _qiregisterPeopleEventRegisterPersonCharacteristics() {
+static bool _qiregisterPeopleEventRegisterPersonDetected() {
   ::qi::ObjectTypeBuilder<PeopleEventRegister<nao_interaction_msgs::PersonDetectedArray> > b;
   QI_VAARGS_APPLY(__QI_REGISTER_ELEMENT, PeopleEventRegister<nao_interaction_msgs::PersonDetectedArray>, peopleCallback)
     b.registerType();
   return true;
   }
-static bool BOOST_PP_CAT(__qi_registration, __LINE__) = _qiregisterPeopleEventRegisterPersonCharacteristics();
+static bool BOOST_PP_CAT(__qi_registration, __LINE__) = _qiregisterPeopleEventRegisterPersonDetected();
 
 } //naoqi
 

--- a/src/event/people.hpp
+++ b/src/event/people.hpp
@@ -103,7 +103,7 @@ private:
   //boost::shared_ptr<recorder::BasicEventRecorder<T> > recorder_;
 
   qi::SessionPtr session_;
-  qi::AnyObject p_memory_, p_people_, p_gaze_, p_face_;
+  qi::AnyObject p_memory_, p_people_, p_gaze_, p_face_, p_waving_;
   unsigned int serviceId;
   std::string name_;
 

--- a/src/event/people.hpp
+++ b/src/event/people.hpp
@@ -19,6 +19,7 @@
 #define PEOPLE_EVENT_REGISTER_HPP
 
 #include <string>
+#include <cmath>
 
 #include <boost/make_shared.hpp>
 #include <boost/shared_ptr.hpp>
@@ -29,6 +30,9 @@
 
 #include <ros/ros.h>
 #include <nao_interaction_msgs/FaceDetected.h>
+#include <nao_interaction_msgs/FacesDetected.h>
+#include <geometry_msgs/PoseArray.h>
+#include <geometry_msgs/Pose.h>
 
 #include <naoqi_driver/tools.hpp>
 #include <naoqi_driver/recorder/globalrecorder.hpp>
@@ -79,13 +83,14 @@ public:
   void isDumping(bool state);
 
   void peopleCallback(std::string &key, qi::AnyValue &value, qi::AnyValue &message);
-  void peopleCallbackMessage(std::string &key, tools::NaoqiFaceDetected &faces, nao_interaction_msgs::FaceDetected &msg);
-  
+  void peopleCallbackMessage(std::string &key, qi::AnyValue &value, nao_interaction_msgs::FacesDetected &msg);
+  void peopleCallbackMessage(std::string &key, qi::AnyValue &value, geometry_msgs::PoseArray &msg);
 
 private:
   void registerCallback();
   void unregisterCallback();
   void onEvent();
+  geometry_msgs::Point toCartesian(float dist, float azi, float inc);
 
 private:
   boost::shared_ptr<converter::PeopleEventConverter<T> > converter_;
@@ -103,27 +108,44 @@ private:
   bool isPublishing_;
   bool isRecording_;
   bool isDumping_;
+  
+  ros::Publisher p;
 
 protected:
   std::vector<std::string> keys_;
 }; // class
 
 
-class FaceDetectedEventRegister: public PeopleEventRegister<nao_interaction_msgs::FaceDetected>
+class FaceDetectedEventRegister: public PeopleEventRegister<nao_interaction_msgs::FacesDetected>
 {
 public:
-  FaceDetectedEventRegister( const std::string& name, const std::vector<std::string> keys, const float& frequency, const qi::SessionPtr& session ) : PeopleEventRegister<nao_interaction_msgs::FaceDetected>(name, keys, frequency, session) {}
+  FaceDetectedEventRegister( const std::string& name, const std::vector<std::string> keys, const float& frequency, const qi::SessionPtr& session ) : PeopleEventRegister<nao_interaction_msgs::FacesDetected>(name, keys, frequency, session) {}
+};
+
+class PersonDetectedEventRegister: public PeopleEventRegister<geometry_msgs::PoseArray>
+{
+public:
+  PersonDetectedEventRegister( const std::string& name, const std::vector<std::string> keys, const float& frequency, const qi::SessionPtr& session ) : PeopleEventRegister<geometry_msgs::PoseArray>(name, keys, frequency, session) {}
 };
 
 //QI_REGISTER_OBJECT(FaceDetectEventRegister, peopleCallback)
+//QI_REGISTER_OBJECT(PersonDetectedEventRegister, peopleCallback)
 
 static bool _qiregisterPeopleEventRegisterFaceDetected() {
-  ::qi::ObjectTypeBuilder<PeopleEventRegister<nao_interaction_msgs::FaceDetected> > b;
-  QI_VAARGS_APPLY(__QI_REGISTER_ELEMENT, PeopleEventRegister<nao_interaction_msgs::FaceDetected>, peopleCallback)
+  ::qi::ObjectTypeBuilder<PeopleEventRegister<nao_interaction_msgs::FacesDetected> > b;
+  QI_VAARGS_APPLY(__QI_REGISTER_ELEMENT, PeopleEventRegister<nao_interaction_msgs::FacesDetected>, peopleCallback)
     b.registerType();
   return true;
   }
 static bool BOOST_PP_CAT(__qi_registration, __LINE__) = _qiregisterPeopleEventRegisterFaceDetected();
+
+static bool _qiregisterPeopleEventRegisterPersonDetected() {
+  ::qi::ObjectTypeBuilder<PeopleEventRegister<geometry_msgs::PoseArray> > b;
+  QI_VAARGS_APPLY(__QI_REGISTER_ELEMENT, PeopleEventRegister<geometry_msgs::PoseArray>, peopleCallback)
+    b.registerType();
+  return true;
+  }
+static bool BOOST_PP_CAT(__qi_registration, __LINE__) = _qiregisterPeopleEventRegisterPersonDetected();
 
 } //naoqi
 

--- a/src/event/sound.cpp
+++ b/src/event/sound.cpp
@@ -1,0 +1,251 @@
+/*
+ * Copyright 2015 Aldebaran
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <iostream>
+#include <vector>
+
+#include <boost/make_shared.hpp>
+
+#include <ros/ros.h>
+
+#include <qi/anyobject.hpp>
+
+#include <naoqi_driver/recorder/globalrecorder.hpp>
+#include <naoqi_driver/message_actions.h>
+
+#include "sound.hpp"
+#include "../tools/from_any_value.hpp"
+
+namespace naoqi
+{
+
+template<class T>
+SoundEventRegister<T>::SoundEventRegister()
+{
+}
+
+template<class T>
+SoundEventRegister<T>::SoundEventRegister(const std::string& name, std::vector<std::string> keys, const float& frequency, const qi::SessionPtr& session )
+  : serviceId(0),
+    keys_(keys),
+    p_memory_(session->service("ALMemory")),
+    p_sound_loc_(session->service("ALSoundLocalization")),
+    session_(session),
+    isStarted_(false),
+    isPublishing_(false),
+    isRecording_(false),
+    isDumping_(false)
+{
+
+  publisher_ = boost::make_shared<publisher::BasicPublisher<T> >( name );
+  recorder_ = boost::make_shared<recorder::BasicEventRecorder<T> >( name );
+  converter_ = boost::make_shared<converter::SoundEventConverter<T> >( name, frequency, session );
+
+  converter_->registerCallback( message_actions::PUBLISH, boost::bind(&publisher::BasicPublisher<T>::publish, publisher_, _1) );
+  converter_->registerCallback( message_actions::RECORD, boost::bind(&recorder::BasicEventRecorder<T>::write, recorder_, _1) );
+  converter_->registerCallback( message_actions::LOG, boost::bind(&recorder::BasicEventRecorder<T>::bufferize, recorder_, _1) );
+
+}
+
+template<class T>
+SoundEventRegister<T>::~SoundEventRegister()
+{
+  stopProcess();
+}
+
+template<class T>
+void SoundEventRegister<T>::resetPublisher(ros::NodeHandle& nh)
+{
+  publisher_->reset(nh);
+}
+
+template<class T>
+void SoundEventRegister<T>::resetRecorder( boost::shared_ptr<naoqi::recorder::GlobalRecorder> gr )
+{
+  recorder_->reset(gr, converter_->frequency());
+}
+
+template<class T>
+void SoundEventRegister<T>::setEnergyComputation(bool run) {
+  p_sound_loc_.call<void>("setParameter", "EnergyComputation", run);
+}
+
+template<class T>
+void SoundEventRegister<T>::setSensitivity(float level) {
+  p_sound_loc_.call<void>("setParameter", "Sensitivity", level);
+}
+
+template<class T>
+void SoundEventRegister<T>::startProcess()
+{
+  boost::mutex::scoped_lock start_lock(mutex_);
+  if (!isStarted_)
+  {
+    if(!serviceId)
+    {
+      std::string serviceName = std::string("ROS-Driver-") + keys_[0];
+      serviceId = session_->registerService(serviceName, this->shared_from_this());
+      for(std::vector<std::string>::const_iterator it = keys_.begin(); it != keys_.end(); ++it) {
+        std::cerr << *it << std::endl;
+        p_memory_.call<void>("subscribeToEvent",it->c_str(), serviceName, "soundCallback");
+      }
+      std::cout << serviceName << " : Start" << std::endl;
+    }
+    isStarted_ = true;
+  }
+}
+
+template<class T>
+void SoundEventRegister<T>::stopProcess()
+{
+  boost::mutex::scoped_lock stop_lock(mutex_);
+  if (isStarted_)
+  {
+      std::string serviceName = std::string("ROS-Driver-") + keys_[0];
+      if(serviceId){
+        for(std::vector<std::string>::const_iterator it = keys_.begin(); it != keys_.end(); ++it) {
+          p_memory_.call<void>("unsubscribeToEvent",it->c_str(), serviceName);
+        }
+        session_->unregisterService(serviceId);
+        serviceId = 0;
+      }
+      std::cout << serviceName << " : Stop" << std::endl;
+      isStarted_ = false;
+  }
+}
+
+template<class T>
+void SoundEventRegister<T>::writeDump(const ros::Time& time)
+{
+  if (isStarted_)
+  {
+    recorder_->writeDump(time);
+  }
+}
+
+template<class T>
+void SoundEventRegister<T>::setBufferDuration(float duration)
+{
+  recorder_->setBufferDuration(duration);
+}
+
+template<class T>
+void SoundEventRegister<T>::isRecording(bool state)
+{
+  boost::mutex::scoped_lock rec_lock(mutex_);
+  isRecording_ = state;
+}
+
+template<class T>
+void SoundEventRegister<T>::isPublishing(bool state)
+{
+  boost::mutex::scoped_lock pub_lock(mutex_);
+  isPublishing_ = state;
+}
+
+template<class T>
+void SoundEventRegister<T>::isDumping(bool state)
+{
+  boost::mutex::scoped_lock dump_lock(mutex_);
+  isDumping_ = state;
+}
+
+template<class T>
+void SoundEventRegister<T>::registerCallback()
+{
+}
+
+template<class T>
+void SoundEventRegister<T>::unregisterCallback()
+{
+}
+
+template<class T>
+void SoundEventRegister<T>::soundCallback(std::string &key, qi::AnyValue &value, qi::AnyValue &message) {
+    T msg = T();
+  
+    soundCallbackMessage(key, value, msg);
+    
+    std::vector<message_actions::MessageAction> actions;
+    boost::mutex::scoped_lock callback_lock(mutex_);
+    if (isStarted_) {
+      // CHECK FOR PUBLISH
+      if ( isPublishing_ && publisher_->isSubscribed() )
+      {
+        actions.push_back(message_actions::PUBLISH);
+      }
+      // CHECK FOR RECORD
+      if ( isRecording_ )
+      {
+        actions.push_back(message_actions::RECORD);
+      }
+      if ( !isDumping_ )
+      {
+        actions.push_back(message_actions::LOG);
+      }
+      if (actions.size() >0)
+      {
+        converter_->callAll( actions, msg );
+      }
+    }
+}
+
+template<class T>
+void SoundEventRegister<T>::soundCallbackMessage(std::string &key, qi::AnyValue &value, nao_interaction_msgs::AudioSourceLocalization &msg) {
+  msg.header.stamp = ros::Time::now();
+  msg.header.frame_id = "Head";
+  
+  qi::AnyReferenceVector anyref;
+  try{
+    anyref = value.asListValuePtr();
+  }
+  catch(std::runtime_error& e)
+  {
+    ROS_INFO_STREAM("Could not transform AnyValue into list: " << e.what());
+  }
+  
+  if(anyref.size() != 4) {
+    ROS_INFO("Could not retrieve sound location");
+    return;
+  }
+  
+  qi::AnyReference ref = anyref[1].content();
+  
+  if(ref.kind() == qi::TypeKind_List && ref.size() == 4) {
+    qi::AnyReference azi, ele, conf, ener;
+    azi = ref[0].content();
+    ele = ref[1].content();
+    conf = ref[2].content();
+    ener = ref[3].content();
+    if(azi.kind() == qi::TypeKind_Float && ele.kind() == qi::TypeKind_Float
+            && conf.kind() == qi::TypeKind_Float && ener.kind() == qi::TypeKind_Float) {
+      msg.azimuth.data = azi.asFloat();
+      msg.elevation.data = ele.asFloat();
+      msg.confidence.data = conf.asFloat();
+      msg.energy.data = ener.asFloat();
+    } else{
+      ROS_INFO("Could not retrieve azi/ele/conf/ener");
+    }
+  } else {
+    ROS_INFO("Could not retrieve sound location");
+  }
+}
+
+// http://stackoverflow.com/questions/8752837/undefined-reference-to-template-class-constructor
+template class SoundEventRegister<nao_interaction_msgs::AudioSourceLocalization>;
+
+}//namespace

--- a/src/event/sound.cpp
+++ b/src/event/sound.cpp
@@ -215,11 +215,11 @@ void SoundEventRegister<T>::soundCallbackMessage(std::string &key, qi::AnyValue 
   }
   catch(std::runtime_error& e)
   {
-    ROS_INFO_STREAM("Could not transform AnyValue into list: " << e.what());
+    ROS_DEBUG_STREAM("Could not transform AnyValue into list: " << e.what());
   }
   
   if(anyref.size() != 4) {
-    ROS_INFO("Could not retrieve sound location");
+    ROS_DEBUG("Could not retrieve sound location");
     return;
   }
   
@@ -238,10 +238,10 @@ void SoundEventRegister<T>::soundCallbackMessage(std::string &key, qi::AnyValue 
       msg.confidence.data = conf.asFloat();
       msg.energy.data = ener.asFloat();
     } else{
-      ROS_INFO("Could not retrieve azi/ele/conf/ener");
+      ROS_DEBUG("Could not retrieve azi/ele/conf/ener");
     }
   } else {
-    ROS_INFO("Could not retrieve sound location");
+    ROS_DEBUG("Could not retrieve sound location");
   }
 }
 

--- a/src/event/sound.hpp
+++ b/src/event/sound.hpp
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2015 Aldebaran
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef SOUND_EVENT_REGISTER_HPP
+#define SOUND_EVENT_REGISTER_HPP
+
+#include <string>
+
+#include <boost/make_shared.hpp>
+#include <boost/shared_ptr.hpp>
+#include <boost/thread/mutex.hpp>
+#include <boost/enable_shared_from_this.hpp>
+
+#include <qi/session.hpp>
+
+#include <ros/ros.h>
+#include <nao_interaction_msgs/AudioSourceLocalization.h>
+
+#include <naoqi_driver/tools.hpp>
+#include <naoqi_driver/recorder/globalrecorder.hpp>
+
+// Converter
+#include "../src/converters/sound.hpp"
+// Publisher
+#include "../src/publishers/basic.hpp"
+// Recorder
+#include "../recorder/basic_event.hpp"
+
+namespace naoqi
+{
+
+/**
+* @brief GlobalRecorder concept interface
+* @note this defines an private concept struct,
+* which each instance has to implement
+* @note a type erasure pattern in implemented here to avoid strict inheritance,
+* thus each possible publisher instance has to implement the virtual functions mentioned in the concept
+*/
+template<class T>
+class SoundEventRegister: public boost::enable_shared_from_this<SoundEventRegister<T> >
+{
+
+public:
+
+  /**
+  * @brief Constructor for recorder interface
+  */
+  SoundEventRegister();
+  SoundEventRegister( const std::string& name, std::vector<std::string> keys, const float& frequency, const qi::SessionPtr& session );
+  ~SoundEventRegister();
+
+  void resetPublisher( ros::NodeHandle& nh );
+  void resetRecorder( boost::shared_ptr<naoqi::recorder::GlobalRecorder> gr );
+
+  void startProcess();
+  void stopProcess();
+
+  void writeDump(const ros::Time& time);
+  void setBufferDuration(float duration);
+
+  void isRecording(bool state);
+  void isPublishing(bool state);
+  void isDumping(bool state);
+
+  void processRemote(int nbOfChannels, int samplesByChannel, qi::AnyValue altimestamp, qi::AnyValue buffer);
+  void soundCallback(std::string &key, qi::AnyValue &value, qi::AnyValue &message);
+  void soundCallbackMessage(std::string &key, qi::AnyValue &value, nao_interaction_msgs::AudioSourceLocalization &msg);
+
+  void setEnergyComputation(bool run);
+  void setSensitivity(float level);
+
+private:
+  void registerCallback();
+  void unregisterCallback();
+  void onEvent();
+
+private:
+  boost::shared_ptr<converter::SoundEventConverter<T> > converter_;
+  boost::shared_ptr<publisher::BasicPublisher<T> > publisher_;
+  boost::shared_ptr<recorder::BasicEventRecorder<T> > recorder_;
+
+  qi::SessionPtr session_;
+  qi::AnyObject p_memory_, p_sound_loc_;
+  unsigned int serviceId;
+
+  boost::mutex mutex_;
+
+  bool isStarted_;
+  bool isPublishing_;
+  bool isRecording_;
+  bool isDumping_;
+  
+protected:
+  std::vector<std::string> keys_;
+
+}; // class
+
+class SoundLocalizedEventRegister: public SoundEventRegister<nao_interaction_msgs::AudioSourceLocalization>
+{
+public:
+  SoundLocalizedEventRegister( const std::string& name, std::vector<std::string> keys, const float& frequency, const qi::SessionPtr& session ) : SoundEventRegister<nao_interaction_msgs::AudioSourceLocalization>(name, keys, frequency, session) {}
+};
+
+//QI_REGISTER_OBJECT(SoundLocalizedEventRegister, soundCallback)
+
+static bool _qiregisterAudioEventRegisterSoundLocalized() {
+  ::qi::ObjectTypeBuilder<SoundEventRegister<nao_interaction_msgs::AudioSourceLocalization> > b;
+  QI_VAARGS_APPLY(__QI_REGISTER_ELEMENT, SoundEventRegister<nao_interaction_msgs::AudioSourceLocalization>, soundCallback)
+    b.registerType();
+  return true;
+  }
+static bool BOOST_PP_CAT(__qi_registration, __LINE__) = _qiregisterAudioEventRegisterSoundLocalized();
+
+} //naoqi
+
+#endif

--- a/src/naoqi_driver.cpp
+++ b/src/naoqi_driver.cpp
@@ -565,6 +565,7 @@ void Driver::registerDefaultConverter()
   size_t camera_depth_resolution      = boot_config_.get( "converters.depth_camera.resolution", 1); // QVGA
   size_t camera_depth_fps             = boot_config_.get( "converters.depth_camera.fps", 10);
   size_t camera_depth_recorder_fps    = boot_config_.get( "converters.depth_camera.recorder_fps", 5);
+  size_t camera_depth_color_space     = boot_config_.get( "converters.depth_camera.color_space", 23);
 
   bool camera_ir_enabled              = boot_config_.get( "converters.ir_camera.enabled", true);
   size_t camera_ir_resolution         = boot_config_.get( "converters.ir_camera.resolution", 1); // QVGA

--- a/src/naoqi_driver.cpp
+++ b/src/naoqi_driver.cpp
@@ -73,6 +73,7 @@
  * SERVICES
  */
 #include "services/robot_config.hpp"
+#include "services/behavior_manager.hpp"
 
 /*
  * RECORDERS
@@ -972,6 +973,10 @@ void Driver::registerService( service::Service srv )
 void Driver::registerDefaultServices()
 {
   registerService( boost::make_shared<service::RobotConfigService>("robot config service", "/naoqi_driver/get_robot_config", sessionPtr_) );
+  registerService( boost::make_shared<service::BehaviorManagerInfoService>("getInstalledBehaviors", "/naoqi_driver/get_installed_behaviors", sessionPtr_) );
+  registerService( boost::make_shared<service::BehaviorManagerInfoService>("getRunningBehaviors", "/naoqi_driver/get_running_behaviors", sessionPtr_) );
+  registerService( boost::make_shared<service::BehaviorManagerControlService>("startBehavior", "/naoqi_driver/start_behaviour", sessionPtr_) );
+  registerService( boost::make_shared<service::BehaviorManagerControlService>("stopBehavior", "/naoqi_driver/stop_behaviour", sessionPtr_) );
 }
 
 std::vector<std::string> Driver::getAvailableConverters()

--- a/src/naoqi_driver.cpp
+++ b/src/naoqi_driver.cpp
@@ -66,6 +66,7 @@
 #include "subscribers/moveto.hpp"
 #include "subscribers/speech.hpp"
 #include "subscribers/animated_speech.hpp"
+#include "subscribers/play_animation.hpp"
 
 /*
  * SERVICES
@@ -935,6 +936,7 @@ void Driver::registerDefaultSubscriber()
   registerSubscriber( boost::make_shared<naoqi::subscriber::MovetoSubscriber>("moveto", "/move_base_simple/goal", sessionPtr_, tf2_buffer_) );
   registerSubscriber( boost::make_shared<naoqi::subscriber::SpeechSubscriber>("speech", "/speech", sessionPtr_) );
   registerSubscriber( boost::make_shared<naoqi::subscriber::AnimatedSpeechSubscriber>("animated_speech", "/animated_speech", sessionPtr_) );
+  registerSubscriber( boost::make_shared<naoqi::subscriber::PlayAnimationSubscriber>("play_animation", "/play_animation", sessionPtr_) );
 }
 
 void Driver::registerService( service::Service srv )

--- a/src/naoqi_driver.cpp
+++ b/src/naoqi_driver.cpp
@@ -26,6 +26,7 @@
  */
 #include "converters/audio.hpp"
 #include "converters/touch.hpp"
+#include "converters/people.hpp"
 #include "converters/camera.hpp"
 #include "converters/diagnostics.hpp"
 #include "converters/imu.hpp"
@@ -86,6 +87,7 @@
 #include "event/basic.hpp"
 #include "event/audio.hpp"
 #include "event/touch.hpp"
+#include "event/people.hpp"
 
 /*
  * STATIC FUNCTIONS INCLUDE
@@ -585,6 +587,7 @@ void Driver::registerDefaultConverter()
   bool bumper_enabled                 = boot_config_.get( "converters.bumper.enabled", true);
   bool tactile_enabled                = boot_config_.get( "converters.tactile.enabled", true);
   bool hand_enabled                   = boot_config_.get( "converters.hand.enabled", true);
+  bool people_enabled                 = boot_config_.get( "converters.people.enabled", true);
   /*
    * The info converter will be called once after it was added to the priority queue. Once it is its turn to be called, its
    * callAll method will be triggered (because InfoPublisher is considered to always have subscribers, isSubscribed always
@@ -840,6 +843,21 @@ void Driver::registerDefaultConverter()
     registerConverter( lc, lp, lr );
   }
   
+  /** PEOPLE **/
+  if ( people_enabled )
+  {
+    std::vector<std::string> people_events;
+    people_events.push_back("FaceDetected");
+    boost::shared_ptr<FaceDetectedEventRegister> event_register =
+      boost::make_shared<FaceDetectedEventRegister>( "face_detected", people_events, 0, sessionPtr_ );
+    insertEventConverter("face_detected", event_register);
+    if (keep_looping) {
+      event_map_.find("face_detected")->second.startProcess();
+    }
+    if (publish_enabled_) {
+      event_map_.find("face_detected")->second.isPublishing(true);
+    }
+  }
 }
 
 

--- a/src/naoqi_driver.cpp
+++ b/src/naoqi_driver.cpp
@@ -867,8 +867,8 @@ void Driver::registerDefaultConverter()
   {
     std::vector<std::string> people_events;
     people_events.push_back("PeoplePerception/PeopleDetected");
-    boost::shared_ptr<PersonCharacteristicsEventRegister> event_register =
-      boost::make_shared<PersonCharacteristicsEventRegister>( "people_detected", people_events, 0, sessionPtr_ );
+    boost::shared_ptr<PersonDetectedEventRegister> event_register =
+      boost::make_shared<PersonDetectedEventRegister>( "people_detected", people_events, 0, sessionPtr_ );
     insertEventConverter("people_detected", event_register);
     if (keep_looping) {
       event_map_.find("people_detected")->second.startProcess();

--- a/src/naoqi_driver.cpp
+++ b/src/naoqi_driver.cpp
@@ -42,6 +42,7 @@
 #include "converters/log.hpp"
 #include "converters/battery.hpp"
 #include "converters/odom.hpp"
+#include "converters/sound.hpp"
 
 /*
  * PUBLISHERS
@@ -90,6 +91,7 @@
 #include "event/audio.hpp"
 #include "event/touch.hpp"
 #include "event/people.hpp"
+#include "event/sound.hpp"
 
 /*
  * STATIC FUNCTIONS INCLUDE
@@ -541,6 +543,11 @@ void Driver::registerDefaultConverter()
   bool audio_enabled                  = boot_config_.get( "converters.audio.enabled", true);
   size_t audio_frequency              = boot_config_.get( "converters.audio.frequency", 1);
 
+  bool sound_enabled                  = boot_config_.get( "converters.sound.enabled", true);
+  size_t sound_frequency              = boot_config_.get( "converters.sound.frequency", 1);
+  bool sound_energy                   = boot_config_.get( "converters.sound.energy", true);
+  float sound_sensitivity             = boot_config_.get( "converters.sound.sensitivity", 0.9);
+
   bool logs_enabled                   = boot_config_.get( "converters.logs.enabled", true);
   size_t logs_frequency               = boot_config_.get( "converters.logs.frequency", 10);
 
@@ -801,6 +808,23 @@ void Driver::registerDefaultConverter()
     }
     if (publish_enabled_) {
       event_map_.find("audio")->second.isPublishing(true);
+    }
+  }
+  
+  if( sound_enabled ) {
+    /** Sound **/
+    std::vector<std::string> sound_events;
+    sound_events.push_back("ALSoundLocalization/SoundLocated");
+    boost::shared_ptr<SoundLocalizedEventRegister> event_register =
+      boost::make_shared<SoundLocalizedEventRegister>( "sound_localized", sound_events, 0, sessionPtr_ );
+    event_register->setEnergyComputation(sound_energy);
+    event_register->setSensitivity(sound_sensitivity);
+    insertEventConverter("sound_localized", event_register);
+    if (keep_looping) {
+      event_map_.find("sound_localized")->second.startProcess();
+    }
+    if (publish_enabled_) {
+      event_map_.find("sound_localized")->second.isPublishing(true);
     }
   }
 

--- a/src/naoqi_driver.cpp
+++ b/src/naoqi_driver.cpp
@@ -588,6 +588,7 @@ void Driver::registerDefaultConverter()
   bool bumper_enabled                 = boot_config_.get( "converters.bumper.enabled", true);
   bool tactile_enabled                = boot_config_.get( "converters.tactile.enabled", true);
   bool hand_enabled                   = boot_config_.get( "converters.hand.enabled", true);
+  bool face_enabled                   = boot_config_.get( "converters.face.enabled", true);
   bool people_enabled                 = boot_config_.get( "converters.people.enabled", true);
   /*
    * The info converter will be called once after it was added to the priority queue. Once it is its turn to be called, its
@@ -845,7 +846,7 @@ void Driver::registerDefaultConverter()
   }
   
   /** PEOPLE **/
-  if ( people_enabled )
+  if ( face_enabled )
   {
     std::vector<std::string> people_events;
     people_events.push_back("FaceDetected");

--- a/src/naoqi_driver.cpp
+++ b/src/naoqi_driver.cpp
@@ -41,6 +41,7 @@
 #include "converters/memory/string.hpp"
 #include "converters/log.hpp"
 #include "converters/odom.hpp"
+#include "converters/battery.hpp"
 
 /*
  * PUBLISHERS
@@ -584,6 +585,8 @@ void Driver::registerDefaultConverter()
   bool odom_enabled                  = boot_config_.get( "converters.odom.enabled", true);
   size_t odom_frequency              = boot_config_.get( "converters.odom.frequency", 10);
   
+  bool battery_enabled                = boot_config_.get( "converters.battery.enabled", true);
+  size_t battery_frequency            = boot_config_.get( "converters.battery.frequency", 10);
 
   bool bumper_enabled                 = boot_config_.get( "converters.bumper.enabled", true);
   bool tactile_enabled                = boot_config_.get( "converters.tactile.enabled", true);
@@ -864,8 +867,8 @@ void Driver::registerDefaultConverter()
   {
     std::vector<std::string> people_events;
     people_events.push_back("PeoplePerception/PeopleDetected");
-    boost::shared_ptr<PersonDetectedEventRegister> event_register =
-      boost::make_shared<PersonDetectedEventRegister>( "people_detected", people_events, 0, sessionPtr_ );
+    boost::shared_ptr<PersonCharacteristicsEventRegister> event_register =
+      boost::make_shared<PersonCharacteristicsEventRegister>( "people_detected", people_events, 0, sessionPtr_ );
     insertEventConverter("people_detected", event_register);
     if (keep_looping) {
       event_map_.find("people_detected")->second.startProcess();

--- a/src/naoqi_driver.cpp
+++ b/src/naoqi_driver.cpp
@@ -65,7 +65,7 @@
 #include "subscribers/teleop.hpp"
 #include "subscribers/moveto.hpp"
 #include "subscribers/speech.hpp"
-
+#include "subscribers/animated_speech.hpp"
 
 /*
  * SERVICES
@@ -934,6 +934,7 @@ void Driver::registerDefaultSubscriber()
   registerSubscriber( boost::make_shared<naoqi::subscriber::TeleopSubscriber>("teleop", "/cmd_vel", "/joint_angles", sessionPtr_) );
   registerSubscriber( boost::make_shared<naoqi::subscriber::MovetoSubscriber>("moveto", "/move_base_simple/goal", sessionPtr_, tf2_buffer_) );
   registerSubscriber( boost::make_shared<naoqi::subscriber::SpeechSubscriber>("speech", "/speech", sessionPtr_) );
+  registerSubscriber( boost::make_shared<naoqi::subscriber::AnimatedSpeechSubscriber>("animated_speech", "/animated_speech", sessionPtr_) );
 }
 
 void Driver::registerService( service::Service srv )

--- a/src/naoqi_driver.cpp
+++ b/src/naoqi_driver.cpp
@@ -859,6 +859,20 @@ void Driver::registerDefaultConverter()
       event_map_.find("face_detected")->second.isPublishing(true);
     }
   }
+  if ( people_enabled )
+  {
+    std::vector<std::string> people_events;
+    people_events.push_back("PeoplePerception/PeopleDetected");
+    boost::shared_ptr<PersonDetectedEventRegister> event_register =
+      boost::make_shared<PersonDetectedEventRegister>( "people_detected", people_events, 0, sessionPtr_ );
+    insertEventConverter("people_detected", event_register);
+    if (keep_looping) {
+      event_map_.find("people_detected")->second.startProcess();
+    }
+    if (publish_enabled_) {
+      event_map_.find("people_detected")->second.isPublishing(true);
+    }
+  }
 }
 
 

--- a/src/services/behavior_manager.cpp
+++ b/src/services/behavior_manager.cpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2015 Aldebaran
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include "behavior_manager.hpp"
+#include "../helpers/driver_helpers.hpp"
+
+namespace naoqi
+{
+namespace service
+{
+
+void BehaviorManagerInfoService::reset( ros::NodeHandle& nh )
+{
+  service_ = nh.advertiseService(topic_, &BehaviorManagerInfoService::callback, this);
+}
+
+bool BehaviorManagerInfoService::callback(nao_interaction_msgs::BehaviorManagerInfoRequest& req, nao_interaction_msgs::BehaviorManagerInfoResponse& resp) {
+  resp.behaviors = p_bm_.call<std::vector<std::string> >(name_);
+  return true;
+}
+
+void BehaviorManagerControlService::reset( ros::NodeHandle& nh )
+{
+  service_ = nh.advertiseService(topic_, &BehaviorManagerControlService::callback, this);
+}
+
+bool BehaviorManagerControlService::callback(nao_interaction_msgs::BehaviorManagerControlRequest& req, nao_interaction_msgs::BehaviorManagerControlResponse& resp) {
+  resp.success = true;
+  if(req.name.compare("ALL")==0 && name_.compare("stopBehavior")==0) { // Stop everything if ALL is given as behavior name
+    p_bm_.call<void>("stopAllBehaviors");
+  } else if(p_bm_.call<bool>("isBehaviorInstalled", req.name)) {
+    if(name_.compare("startBehavior") == 0) {
+      if(p_bm_.call<bool>("isBehaviorRunning", req.name)) {
+        return false; // To make clear that it is successfully started but the service call failed because it was already running
+      } else {
+        p_bm_.call<void>(name_, req.name);
+      }
+    } else {
+      if(!p_bm_.call<bool>("isBehaviorRunning", req.name)) {
+        return false;
+      } else {
+        p_bm_.call<void>(name_, req.name);
+      }
+    }
+  } else {
+    resp.success = false;
+    return false;
+  }
+  return true;
+}
+
+}
+}

--- a/src/services/behavior_manager.hpp
+++ b/src/services/behavior_manager.hpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2015 Aldebaran
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+
+#ifndef BEHAVIOR_MANAGER_SERVICE_HPP
+#define BEHAVIOR_MANAGER_SERVICE_HPP
+
+#include <iostream>
+
+#include <ros/node_handle.h>
+#include <ros/service_server.h>
+
+#include <nao_interaction_msgs/BehaviorManagerInfo.h>
+#include <nao_interaction_msgs/BehaviorManagerControl.h>
+#include <qi/session.hpp>
+
+namespace naoqi
+{
+namespace service
+{
+
+class BehaviorManagerService
+{
+public:
+  BehaviorManagerService( const std::string& name, const std::string& topic, const qi::SessionPtr& session ) :
+      name_(name),
+      topic_(topic),
+      session_(session),
+      p_bm_(session->service("ALBehaviorManager")) {}
+
+  ~BehaviorManagerService(){};
+
+  std::string name() const
+  {
+    return name_;
+  }
+
+  std::string topic() const
+  {
+    return topic_;
+  }
+
+  virtual void reset( ros::NodeHandle& nh )=0;
+
+protected:
+  const std::string name_;
+  const std::string topic_;
+
+  const qi::SessionPtr& session_;
+  qi::AnyObject p_bm_;
+  ros::ServiceServer service_;
+};
+
+class BehaviorManagerInfoService : public BehaviorManagerService
+{
+public:
+  BehaviorManagerInfoService(const std::string& name, const std::string& topic, const qi::SessionPtr& session) : BehaviorManagerService(name, topic, session) {}
+  void reset(ros::NodeHandle& nh);
+  bool callback(nao_interaction_msgs::BehaviorManagerInfoRequest& req, nao_interaction_msgs::BehaviorManagerInfoResponse& resp);
+
+};
+
+class BehaviorManagerControlService : public BehaviorManagerService
+{
+public:
+  BehaviorManagerControlService(const std::string& name, const std::string& topic, const qi::SessionPtr& session) : BehaviorManagerService(name, topic, session) {}
+  void reset(ros::NodeHandle& nh);
+  bool callback(nao_interaction_msgs::BehaviorManagerControlRequest& req, nao_interaction_msgs::BehaviorManagerControlResponse& resp);
+
+};
+
+} // service
+} // naoqi
+#endif

--- a/src/subscribers/animated_speech.cpp
+++ b/src/subscribers/animated_speech.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2015 Aldebaran
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/*
+ * LOCAL includes
+ */
+#include "animated_speech.hpp"
+
+
+namespace naoqi
+{
+namespace subscriber
+{
+
+  AnimatedSpeechSubscriber::AnimatedSpeechSubscriber( const std::string& name, const std::string& animated_speech_topic, const qi::SessionPtr& session ):
+    animated_speech_topic_(animated_speech_topic),
+    BaseSubscriber( name, animated_speech_topic, session ),
+    p_tts_( session->service("ALAnimatedSpeech") )
+  {}
+
+  void AnimatedSpeechSubscriber::reset( ros::NodeHandle& nh )
+  {
+    sub_animated_speech_ = nh.subscribe( animated_speech_topic_, 10, &AnimatedSpeechSubscriber::animated_speech_callback, this );
+
+    is_initialized_ = true;
+  }
+
+  void AnimatedSpeechSubscriber::animated_speech_callback( const std_msgs::StringConstPtr& string_msg )
+  {
+    p_tts_.async<void>("say", string_msg->data);
+  }
+
+}// subscriber 
+}// naoqi

--- a/src/subscribers/animated_speech.hpp
+++ b/src/subscribers/animated_speech.hpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2015 Aldebaran
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+
+#ifndef ANIMATED_SPEECH_SUBSCRIBER_HPP
+#define ANIMATED_SPEECH_SUBSCRIBER_HPP
+
+/*
+ * LOCAL includes
+ */
+#include "subscriber_base.hpp"
+
+/*
+ * ROS includes
+ */
+#include <ros/ros.h>
+#include <std_msgs/String.h>
+
+namespace naoqi
+{
+namespace subscriber
+{
+
+  class AnimatedSpeechSubscriber: public BaseSubscriber<AnimatedSpeechSubscriber>
+  {
+  public:
+    AnimatedSpeechSubscriber( const std::string& name, const std::string& speech_topic, const qi::SessionPtr& session );
+    ~AnimatedSpeechSubscriber(){}
+
+    void reset( ros::NodeHandle& nh );
+    void animated_speech_callback( const std_msgs::StringConstPtr& speech_msg );
+
+  private:
+
+    std::string animated_speech_topic_;
+
+    qi::AnyObject p_tts_;
+    ros::Subscriber sub_animated_speech_;
+
+
+
+  }; // class AnimatedSpeech
+
+} // subscriber
+}// naoqi
+#endif

--- a/src/subscribers/play_animation.cpp
+++ b/src/subscribers/play_animation.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2015 Aldebaran
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+/*
+ * LOCAL includes
+ */
+#include "play_animation.hpp"
+
+
+namespace naoqi
+{
+namespace subscriber
+{
+
+PlayAnimationSubscriber::PlayAnimationSubscriber( const std::string& name, const std::string& pa_topic, const qi::SessionPtr& session ):
+  pa_topic_(pa_topic),
+  BaseSubscriber( name, pa_topic, session ),
+  p_animation_player_( session->service("ALAnimationPlayer") )
+{}
+
+void PlayAnimationSubscriber::reset( ros::NodeHandle& nh )
+{
+  sub_pa_ = nh.subscribe( pa_topic_, 10, &PlayAnimationSubscriber::pa_callback, this );
+
+  is_initialized_ = true;
+}
+
+void PlayAnimationSubscriber::pa_callback( const std_msgs::StringConstPtr& string_msg )
+{
+  if(string_msg->data.find("/") != std::string::npos)
+    p_animation_player_.async<void>("run", string_msg->data);
+  else
+    p_animation_player_.async<void>("runTag", string_msg->data);
+}
+
+} //publisher
+} // naoqi

--- a/src/subscribers/play_animation.hpp
+++ b/src/subscribers/play_animation.hpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2015 Aldebaran
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+
+#ifndef PLAY_ANIMATION_SUBSCRIBER_HPP
+#define PLAY_ANIMATION_SUBSCRIBER_HPP
+
+/*
+ * LOCAL includes
+ */
+#include "subscriber_base.hpp"
+
+/*
+ * ROS includes
+ */
+#include <ros/ros.h>
+#include <std_msgs/String.h>
+
+namespace naoqi
+{
+namespace subscriber
+{
+
+class PlayAnimationSubscriber: public BaseSubscriber<PlayAnimationSubscriber>
+{
+public:
+  PlayAnimationSubscriber( const std::string& name, const std::string& pa_topic, const qi::SessionPtr& session );
+  ~PlayAnimationSubscriber(){}
+
+  void reset( ros::NodeHandle& nh );
+  void pa_callback( const std_msgs::StringConstPtr& speech_msg );
+
+private:
+
+  std::string pa_topic_;
+
+  qi::AnyObject p_animation_player_;
+  ros::Subscriber sub_pa_;
+
+
+
+}; // class Speech
+
+} // subscriber
+}// naoqi
+#endif

--- a/src/tools/from_any_value.cpp
+++ b/src/tools/from_any_value.cpp
@@ -181,6 +181,473 @@ NaoqiImage fromAnyValueToNaoqiImage(qi::AnyValue& value){
   return result;
 }
 
+NaoqiTimeStamp fromAnyValueToTimeStamp(qi::AnyReference& anyrefs, NaoqiTimeStamp& result){
+  qi::AnyReference ref;
+  std::ostringstream ss;
+
+  /** timestamp_s **/
+  ref = anyrefs[0].content();
+  if(ref.kind() == qi::TypeKind_Int)
+  {
+    result.timestamp_s = ref.asInt32();
+  }
+  else
+  {
+    ss << "Could not retrieve timestamp_s";
+    throw std::runtime_error(ss.str());
+  }
+
+  /** timestamp_us **/
+  ref = anyrefs[1].content();
+  if(ref.kind() == qi::TypeKind_Int)
+  {
+    result.timestamp_us = ref.asInt32();
+  }
+  else
+  {
+    ss << "Could not retrieve timestamp_us";
+    throw std::runtime_error(ss.str());
+  }
+
+  return result;
+}
+
+NaoqiEyePoints fromAnyValueToEyePoints(qi::AnyReference& anyrefs, NaoqiEyePoints& result){
+  qi::AnyReference ref;
+  std::ostringstream ss;
+
+  // eye_center
+  ref = anyrefs[0].content();
+  if(ref.kind() == qi::TypeKind_Float)
+  {
+    result.eye_center_x = ref.asFloat();
+  }
+  else
+  {
+    ss << "Could not retrieve eye_center_x";
+    throw std::runtime_error(ss.str());
+  }
+
+  ref = anyrefs[1].content();
+  if(ref.kind() == qi::TypeKind_Float)
+  {
+    result.eye_center_y = ref.asFloat();
+  }
+  else
+  {
+    ss << "Could not retrieve eye_center_y";
+    throw std::runtime_error(ss.str());
+  }
+
+  // nose_side_limit
+  ref = anyrefs[2].content();
+  if(ref.kind() == qi::TypeKind_Float)
+  {
+    result.nose_side_limit_x = ref.asFloat();
+  }
+  else
+  {
+    ss << "Could not retrieve nose_side_limit_x";
+    throw std::runtime_error(ss.str());
+  }
+
+  ref = anyrefs[3].content();
+  if(ref.kind() == qi::TypeKind_Float)
+  {
+    result.nose_side_limit_y = ref.asFloat();
+  }
+  else
+  {
+    ss << "Could not retrieve nose_side_limit_y";
+    throw std::runtime_error(ss.str());
+  }
+
+  // ear_side_limit
+  ref = anyrefs[4].content();
+  if(ref.kind() == qi::TypeKind_Float)
+  {
+    result.ear_side_limit_x = ref.asFloat();
+  }
+  else
+  {
+    ss << "Could not retrieve ear_side_limit_x";
+    throw std::runtime_error(ss.str());
+  }
+
+  ref = anyrefs[5].content();
+  if(ref.kind() == qi::TypeKind_Float)
+  {
+    result.ear_side_limit_y = ref.asFloat();
+  }
+  else
+  {
+    ss << "Could not retrieve ear_side_limit_y";
+    throw std::runtime_error(ss.str());
+  }
+
+  return result;
+}
+
+NaoqiNosePoints fromAnyValueToNosePoints(qi::AnyReference& anyrefs, NaoqiNosePoints& result){
+  qi::AnyReference ref;
+  std::ostringstream ss;
+
+  // bottom_center_limit
+  ref = anyrefs[0].content();
+  if(ref.kind() == qi::TypeKind_Float)
+  {
+    result.bottom_center_limit_x = ref.asFloat();
+  }
+  else
+  {
+    ss << "Could not retrieve bottom_center_limit_x";
+    throw std::runtime_error(ss.str());
+  }
+
+  ref = anyrefs[1].content();
+  if(ref.kind() == qi::TypeKind_Float)
+  {
+    result.bottom_center_limit_y = ref.asFloat();
+  }
+  else
+  {
+    ss << "Could not retrieve bottom_center_limit_y";
+    throw std::runtime_error(ss.str());
+  }
+
+  // bottom_left_limit
+  ref = anyrefs[2].content();
+  if(ref.kind() == qi::TypeKind_Float)
+  {
+    result.bottom_left_limit_x = ref.asFloat();
+  }
+  else
+  {
+    ss << "Could not retrieve bottom_left_limit_x";
+    throw std::runtime_error(ss.str());
+  }
+
+  ref = anyrefs[3].content();
+  if(ref.kind() == qi::TypeKind_Float)
+  {
+    result.bottom_left_limit_y = ref.asFloat();
+  }
+  else
+  {
+    ss << "Could not retrieve bottom_left_limit_y";
+    throw std::runtime_error(ss.str());
+  }
+
+  // bottom_right_limit
+  ref = anyrefs[4].content();
+  if(ref.kind() == qi::TypeKind_Float)
+  {
+    result.bottom_right_limit_x = ref.asFloat();
+  }
+  else
+  {
+    ss << "Could not retrieve bottom_right_limit_x";
+    throw std::runtime_error(ss.str());
+  }
+
+  ref = anyrefs[5].content();
+  if(ref.kind() == qi::TypeKind_Float)
+  {
+    result.bottom_right_limit_y = ref.asFloat();
+  }
+  else
+  {
+    ss << "Could not retrieve bottom_right_limit_y";
+    throw std::runtime_error(ss.str());
+  }
+
+  return result;
+}
+
+NaoqiMouthPoints fromAnyValueToMouthPoints(qi::AnyReference& anyrefs, NaoqiMouthPoints& result){
+  qi::AnyReference ref;
+  std::ostringstream ss;
+
+  // left_limit
+  ref = anyrefs[0].content();
+  if(ref.kind() == qi::TypeKind_Float)
+  {
+    result.left_limit_x = ref.asFloat();
+  }
+  else
+  {
+    ss << "Could not retrieve left_limit_x";
+    throw std::runtime_error(ss.str());
+  }
+
+  ref = anyrefs[1].content();
+  if(ref.kind() == qi::TypeKind_Float)
+  {
+    result.left_limit_y = ref.asFloat();
+  }
+  else
+  {
+    ss << "Could not retrieve left_limit_y";
+    throw std::runtime_error(ss.str());
+  }
+
+  // right_limit
+  ref = anyrefs[0].content();
+  if(ref.kind() == qi::TypeKind_Float)
+  {
+    result.right_limit_x = ref.asFloat();
+  }
+  else
+  {
+    ss << "Could not retrieve right_limit_x";
+    throw std::runtime_error(ss.str());
+  }
+
+  ref = anyrefs[1].content();
+  if(ref.kind() == qi::TypeKind_Float)
+  {
+    result.right_limit_y = ref.asFloat();
+  }
+  else
+  {
+    ss << "Could not retrieve right_limit_y";
+    throw std::runtime_error(ss.str());
+  }
+
+  // top_limit
+  ref = anyrefs[0].content();
+  if(ref.kind() == qi::TypeKind_Float)
+  {
+    result.top_limit_x = ref.asFloat();
+  }
+  else
+  {
+    ss << "Could not retrieve top_limit_x";
+    throw std::runtime_error(ss.str());
+  }
+
+  ref = anyrefs[1].content();
+  if(ref.kind() == qi::TypeKind_Float)
+  {
+    result.top_limit_y = ref.asFloat();
+  }
+  else
+  {
+    ss << "Could not retrieve top_limit_y";
+    throw std::runtime_error(ss.str());
+  }
+
+  return result;
+}
+
+NaoqiShapeInfo fromAnyValueToShapeInfo(qi::AnyReference& anyrefs, NaoqiShapeInfo& result){
+  qi::AnyReference ref;
+  std::ostringstream ss;
+  //0
+  //alpha
+  ref = anyrefs[1].content();
+  if(ref.kind() == qi::TypeKind_Float)
+  {
+    result.alpha = ref.asFloat();
+  }
+  else
+  {
+    ss << "Could not retrieve alpha";
+    throw std::runtime_error(ss.str());
+  }
+
+  //beta
+  ref = anyrefs[2].content();
+  if(ref.kind() == qi::TypeKind_Float)
+  {
+    result.beta = ref.asFloat();
+  }
+  else
+  {
+    ss << "Could not retrieve  beta";
+    throw std::runtime_error(ss.str());
+  }
+
+  //sizeX
+  ref = anyrefs[3].content();
+  if(ref.kind() == qi::TypeKind_Float)
+  {
+    result.sizeX = ref.asFloat();
+  }
+  else
+  {
+    ss << "Could not retrieve sizeX";
+    throw std::runtime_error(ss.str());
+  }
+
+  //sizeY
+  ref = anyrefs[4].content();
+  if(ref.kind() == qi::TypeKind_Float)
+  {
+    result.sizeY = ref.asFloat();
+  }
+  else
+  {
+    ss << "Could not retrieve sizeY";
+    throw std::runtime_error(ss.str());
+  }
+  return result;
+}
+
+NaoqiExtraInfo fromAnyValueToExtraInfo(qi::AnyReference& anyrefs, NaoqiExtraInfo& result){
+  qi::AnyReference ref;
+  std::ostringstream ss;
+
+  //faceID
+  ref = anyrefs[0].content();
+  if(ref.kind() == qi::TypeKind_Int)
+  {
+    result.face_id = ref.asInt32();
+  }
+  else
+  {
+    ss << "Could not retrieve faceID";
+    throw std::runtime_error(ss.str());
+  }
+
+  //scoreReco
+  ref = anyrefs[1].content();
+  if(ref.kind() == qi::TypeKind_Float)
+  {
+    result.score_reco = ref.asFloat();
+  }
+  else
+  {
+    ss << "Could not retrieve  beta";
+    throw std::runtime_error(ss.str());
+  }
+
+  //faceLabel
+  ref = anyrefs[2].content();
+  if(ref.kind() == qi::TypeKind_String)
+  {
+    result.face_label = ref.asString();
+  }
+  else
+  {
+    ss << "Could not retrieve faceLabel";
+    throw std::runtime_error(ss.str());
+  }
+
+  /* leftEyePoints */
+  ref = anyrefs[3].content();
+  result.left_eye_points = fromAnyValueToEyePoints(ref, result.left_eye_points);
+
+  /* rightEyePoints */
+  ref = anyrefs[4].content();
+  result.right_eye_points = fromAnyValueToEyePoints(ref, result.right_eye_points);
+
+  /* nosePoints */
+  ref = anyrefs[7].content();
+  result.nose_points = fromAnyValueToNosePoints(ref, result.nose_points);
+
+  /* mouthPoints */
+  ref = anyrefs[8].content();
+  result.mouth_points = fromAnyValueToMouthPoints(ref, result.mouth_points);
+
+  return result;
+}
+
+NaoqiFaceInfo fromAnyValueToFaceInfo(qi::AnyReference& anyrefs, NaoqiFaceInfo& result){
+  qi::AnyReference ref;
+  std::ostringstream ss;
+
+  /* ShapeInfo */
+  ref = anyrefs[0].content();
+  result.shape_info = fromAnyValueToShapeInfo(ref, result.shape_info);
+
+  /* ExtraInfo */
+  ref = anyrefs[1].content();
+  NaoqiExtraInfo extra_info;
+  result.extra_info.push_back(fromAnyValueToExtraInfo(ref, extra_info));
+
+  return result;
+}
+
+NaoqiFaceDetected fromAnyValueToNaoqiFaceDetected(qi::AnyValue& value){
+  qi::AnyReferenceVector anyref;
+  NaoqiFaceDetected result;
+  std::ostringstream ss;
+  try{
+    anyref = value.asListValuePtr();
+  }
+  catch(std::runtime_error& e)
+  {
+    ss << "Could not transform AnyValue into list: " << e.what();
+    throw std::runtime_error(ss.str());
+  }
+  qi::AnyReference ref;
+
+  if ( anyref.size() != 5 ) {
+    return result;
+  }
+  /** TimeStamp_ **/
+  ref = anyref[0].content();
+  if(ref.kind() == qi::TypeKind_List)
+  {
+    result.timestamp = fromAnyValueToTimeStamp(ref, result.timestamp);
+  }
+  else
+  {
+    ss << "Could not retrieve timestamp";
+    throw std::runtime_error(ss.str());
+  }
+
+  qi::AnyReferenceVector vec;
+  vec = anyref[1].asListValuePtr(); // FaceInfo[N]
+  for(int i = 0; i < vec.size()-1; i++) // N
+  {
+    qi::AnyReference ref2 = vec[i].content();
+    struct NaoqiFaceInfo face_info;
+    face_info = fromAnyValueToFaceInfo(ref2, face_info);
+    result.face_info.push_back(face_info);
+  }
+
+  //CameraPose_InTorsoFrame,
+  ref = anyref[2].content();
+  for (int i = 0; i < 6; i++ ){
+    if(ref[i].content().kind() == qi::TypeKind_Float)
+    {
+      result.camera_pose_in_torso_frame[i] = ref[i].content().asFloat();
+    }
+    else
+    {
+      ss << "Could not retrieve Position6D";
+      throw std::runtime_error(ss.str());
+    }
+  }
+  //CameraPose_InRobotFrame,
+  ref = anyref[3].content();
+  for (int i = 0; i < 6; i++ ){
+    if(ref[i].content().kind() == qi::TypeKind_Float)
+    {
+      result.camera_pose_in_robot_frame[i] = ref[i].content().asFloat();
+    }
+    else
+    {
+      ss << "Could not retrieve Position6D";
+      throw std::runtime_error(ss.str());
+    }
+  }
+  //Camera_Id
+  ref = anyref[4].content();
+  if(ref.kind() == qi::TypeKind_Int)
+  {
+    result.camera_id = ref.asInt32();
+  }
+  else
+  {
+    ss << "Could not retrieve timestamp_us";
+    throw std::runtime_error(ss.str());
+  }
+
+  return result;
+}
 
 std::vector<float> fromAnyValueToFloatVector(qi::AnyValue& value, std::vector<float>& result){
   qi::AnyReferenceVector anyrefs = value.asListValuePtr();

--- a/src/tools/from_any_value.cpp
+++ b/src/tools/from_any_value.cpp
@@ -584,7 +584,7 @@ NaoqiFaceDetected fromAnyValueToNaoqiFaceDetected(qi::AnyValue& value){
   qi::AnyReference ref;
 
   if ( anyref.size() != 5 ) {
-    return result;
+    throw std::runtime_error("AnyValue does not have the expected size to be transformed to face detected");
   }
   /** TimeStamp_ **/
   ref = anyref[0].content();
@@ -610,7 +610,7 @@ NaoqiFaceDetected fromAnyValueToNaoqiFaceDetected(qi::AnyValue& value){
 
   //CameraPose_InTorsoFrame,
   ref = anyref[2].content();
-  for (int i = 0; i < 6; i++ ){
+  for (int i = 0; i < ref.size(); i++ ){
     if(ref[i].content().kind() == qi::TypeKind_Float)
     {
       result.camera_pose_in_torso_frame[i] = ref[i].content().asFloat();
@@ -623,7 +623,7 @@ NaoqiFaceDetected fromAnyValueToNaoqiFaceDetected(qi::AnyValue& value){
   }
   //CameraPose_InRobotFrame,
   ref = anyref[3].content();
-  for (int i = 0; i < 6; i++ ){
+  for (int i = 0; i < ref.size(); i++ ){
     if(ref[i].content().kind() == qi::TypeKind_Float)
     {
       result.camera_pose_in_robot_frame[i] = ref[i].content().asFloat();
@@ -715,7 +715,7 @@ NaoqiPersonDetected fromAnyValueToNaoqiPersonDetected(qi::AnyValue& value) {
     qi::AnyReference ref;
   
     if ( anyref.size() != 5 ) {
-      return result;
+      throw std::runtime_error("AnyValue does not have the expected size to be transformed to person detected");
     }
     /** TimeStamp_ **/
     ref = anyref[0].content();
@@ -741,7 +741,7 @@ NaoqiPersonDetected fromAnyValueToNaoqiPersonDetected(qi::AnyValue& value) {
     
     //CameraPose_InTorsoFrame,
     ref = anyref[2].content();
-    for (int i = 0; i < 6; i++ ){
+    for (int i = 0; i < ref.size(); i++ ){
       if(ref[i].content().kind() == qi::TypeKind_Float)
       {
         result.camera_pose_in_torso_frame[i] = ref[i].content().asFloat();
@@ -754,7 +754,7 @@ NaoqiPersonDetected fromAnyValueToNaoqiPersonDetected(qi::AnyValue& value) {
     }
     //CameraPose_InRobotFrame,
     ref = anyref[3].content();
-    for (int i = 0; i < 6; i++ ){
+    for (int i = 0; i < ref.size(); i++ ){
       if(ref[i].content().kind() == qi::TypeKind_Float)
       {
         result.camera_pose_in_robot_frame[i] = ref[i].content().asFloat();

--- a/src/tools/from_any_value.cpp
+++ b/src/tools/from_any_value.cpp
@@ -649,6 +649,137 @@ NaoqiFaceDetected fromAnyValueToNaoqiFaceDetected(qi::AnyValue& value){
   return result;
 }
 
+NaoqiPersonInfo fromAnyValueToPersonInfo(qi::AnyReference& anyrefs, NaoqiPersonInfo& result){
+  qi::AnyReference ref;
+  std::ostringstream ss;
+  
+  ref = anyrefs[0].content();
+  if(ref.kind() == qi::TypeKind_Int)
+  {
+    result.id = ref.asInt32();
+  }
+  else
+  {
+    ss << "Could not retrieve id";
+    throw std::runtime_error(ss.str());
+  }
+  
+  ref = anyrefs[1].content();
+  if(ref.kind() == qi::TypeKind_Float)
+  {
+    result.distance_to_camera = ref.asFloat();
+  }
+  else
+  {
+    ss << "Could not retrieve distance";
+    throw std::runtime_error(ss.str());
+  }
+  
+  ref = anyrefs[2].content();
+  if(ref.kind() == qi::TypeKind_Float)
+  {
+    result.pitch_angle_in_image = ref.asFloat();
+  }
+  else
+  {
+    ss << "Could not retrieve pitch";
+    throw std::runtime_error(ss.str());
+  }
+  
+  ref = anyrefs[3].content();
+  if(ref.kind() == qi::TypeKind_Float)
+  {
+    result.yaw_angle_in_image = ref.asFloat();
+  }
+  else
+  {
+    ss << "Could not retrieve yaw";
+    throw std::runtime_error(ss.str());
+  }
+
+  return result;
+}
+
+NaoqiPersonDetected fromAnyValueToNaoqiPersonDetected(qi::AnyValue& value) {
+    qi::AnyReferenceVector anyref;
+    NaoqiPersonDetected result;
+    std::ostringstream ss;
+    try{
+      anyref = value.asListValuePtr();
+    }
+    catch(std::runtime_error& e)
+    {
+      ss << "Could not transform AnyValue into list: " << e.what();
+      throw std::runtime_error(ss.str());
+    }
+    qi::AnyReference ref;
+  
+    if ( anyref.size() != 5 ) {
+      return result;
+    }
+    /** TimeStamp_ **/
+    ref = anyref[0].content();
+    if(ref.kind() == qi::TypeKind_List)
+    {
+      result.timestamp = fromAnyValueToTimeStamp(ref, result.timestamp);
+    }
+    else
+    {
+      ss << "Could not retrieve timestamp";
+      throw std::runtime_error(ss.str());
+    }
+  
+    qi::AnyReferenceVector vec;
+    vec = anyref[1].asListValuePtr(); // FaceInfo[N]
+    for(int i = 0; i < vec.size(); i++) // N
+    {
+      qi::AnyReference ref2 = vec[i].content();
+      struct NaoqiPersonInfo person_info;
+      person_info = fromAnyValueToPersonInfo(ref2, person_info);
+      result.person_info.push_back(person_info);
+    }
+    
+    //CameraPose_InTorsoFrame,
+    ref = anyref[2].content();
+    for (int i = 0; i < 6; i++ ){
+      if(ref[i].content().kind() == qi::TypeKind_Float)
+      {
+        result.camera_pose_in_torso_frame[i] = ref[i].content().asFloat();
+      }
+      else
+      {
+        ss << "Could not retrieve Position6D";
+        throw std::runtime_error(ss.str());
+      }
+    }
+    //CameraPose_InRobotFrame,
+    ref = anyref[3].content();
+    for (int i = 0; i < 6; i++ ){
+      if(ref[i].content().kind() == qi::TypeKind_Float)
+      {
+        result.camera_pose_in_robot_frame[i] = ref[i].content().asFloat();
+      }
+      else
+      {
+        ss << "Could not retrieve Position6D";
+        throw std::runtime_error(ss.str());
+      }
+    }
+    //Camera_Id
+    ref = anyref[4].content();
+    if(ref.kind() == qi::TypeKind_Int)
+    {
+      result.camera_id = ref.asInt32();
+    }
+    else
+    {
+      ss << "Could not retrieve timestamp_us";
+      throw std::runtime_error(ss.str());
+    }
+  
+    return result;
+}
+
 std::vector<float> fromAnyValueToFloatVector(qi::AnyValue& value, std::vector<float>& result){
   qi::AnyReferenceVector anyrefs = value.asListValuePtr();
 

--- a/src/tools/from_any_value.hpp
+++ b/src/tools/from_any_value.hpp
@@ -22,7 +22,7 @@
 * LOCAL includes
 */
 #include "naoqi_image.hpp"
-
+#include "naoqi_facedetected.hpp"
 /*
 * ALDEBARAN includes
 */
@@ -33,6 +33,8 @@ namespace naoqi {
 namespace tools {
 
 NaoqiImage fromAnyValueToNaoqiImage(qi::AnyValue& value);
+
+NaoqiFaceDetected fromAnyValueToNaoqiFaceDetected(qi::AnyValue& value);
 
 std::vector<std::string> fromAnyValueToStringVector(qi::AnyValue& value, std::vector<std::string>& result);
 

--- a/src/tools/from_any_value.hpp
+++ b/src/tools/from_any_value.hpp
@@ -36,6 +36,8 @@ NaoqiImage fromAnyValueToNaoqiImage(qi::AnyValue& value);
 
 NaoqiFaceDetected fromAnyValueToNaoqiFaceDetected(qi::AnyValue& value);
 
+NaoqiPersonDetected fromAnyValueToNaoqiPersonDetected(qi::AnyValue& value);
+
 std::vector<std::string> fromAnyValueToStringVector(qi::AnyValue& value, std::vector<std::string>& result);
 
 std::vector<float> fromAnyValueToFloatVector(qi::AnyValue& value, std::vector<float>& result);

--- a/src/tools/naoqi_facedetected.hpp
+++ b/src/tools/naoqi_facedetected.hpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2015 Aldebaran
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef NAOQI_FACEDETECTED_HPP
+#define NAOQI_FACEDETECTED_HPP
+
+#include <string>
+#include <vector>
+
+namespace naoqi{
+
+namespace tools {
+
+/**
+ * @brief The struct describing an facedetected retrieved by ALFaceDetection
+ *        This specification can be found here:
+ *        http://doc.aldebaran.com/2-1/naoqi/peopleperception/alfacedetection.html#alfacedetection
+ */
+struct NaoqiEyePoints{
+  float eye_center_x;
+  float eye_center_y;
+  float nose_side_limit_x;
+  float nose_side_limit_y;
+  float ear_side_limit_x;
+  float ear_side_limit_y;
+};
+struct NaoqiNosePoints{
+  float bottom_center_limit_x;
+  float bottom_center_limit_y;
+  float bottom_left_limit_x;
+  float bottom_left_limit_y;
+  float bottom_right_limit_x;
+  float bottom_right_limit_y;
+};
+struct NaoqiMouthPoints{
+  float left_limit_x;
+  float left_limit_y;
+  float right_limit_x;
+  float right_limit_y;
+  float top_limit_x;
+  float top_limit_y;
+};
+struct NaoqiExtraInfo{
+  int face_id;
+  float score_reco;
+  std::string face_label;
+  struct NaoqiEyePoints left_eye_points;
+  struct NaoqiEyePoints right_eye_points;
+  struct NaoqiNosePoints nose_points;
+  struct NaoqiMouthPoints mouth_points;
+};
+struct NaoqiShapeInfo{
+  float alpha;
+  float beta;
+  float sizeX;
+  float sizeY;
+};
+struct NaoqiFaceInfo{
+  struct NaoqiShapeInfo shape_info;
+  std::vector<struct NaoqiExtraInfo> extra_info;
+};
+struct NaoqiTimeStamp{
+  int timestamp_s;
+  int timestamp_us;
+};
+
+
+struct NaoqiFaceDetected{
+  //TimeStamp,
+  struct NaoqiTimeStamp timestamp;
+  //[ FaceInfo[N], Time_Filtered_Reco_Info ]
+  std::vector<struct NaoqiFaceInfo> face_info;
+  //CameraPose_InTorsoFrame,
+  float camera_pose_in_torso_frame[6];
+  //CameraPose_InRobotFrame,
+  float camera_pose_in_robot_frame[6];
+  //Camera_Id
+  int camera_id;
+};
+
+}
+
+}
+
+#endif // NAOQI_FACEDETECTED_HPP

--- a/src/tools/naoqi_facedetected.hpp
+++ b/src/tools/naoqi_facedetected.hpp
@@ -77,6 +77,12 @@ struct NaoqiTimeStamp{
   int timestamp_s;
   int timestamp_us;
 };
+struct NaoqiPersonInfo{
+    int id;
+    float distance_to_camera;
+    float pitch_angle_in_image;
+    float yaw_angle_in_image;
+};
 
 
 struct NaoqiFaceDetected{
@@ -84,6 +90,19 @@ struct NaoqiFaceDetected{
   struct NaoqiTimeStamp timestamp;
   //[ FaceInfo[N], Time_Filtered_Reco_Info ]
   std::vector<struct NaoqiFaceInfo> face_info;
+  //CameraPose_InTorsoFrame,
+  float camera_pose_in_torso_frame[6];
+  //CameraPose_InRobotFrame,
+  float camera_pose_in_robot_frame[6];
+  //Camera_Id
+  int camera_id;
+};
+
+struct NaoqiPersonDetected{
+  //TimeStamp,
+  struct NaoqiTimeStamp timestamp;
+  // Person info
+  std::vector<struct NaoqiPersonInfo> person_info;
   //CameraPose_InTorsoFrame,
   float camera_pose_in_torso_frame[6];
   //CameraPose_InRobotFrame,


### PR DESCRIPTION
Hi,

I am part of the MuMMER project and we recently started using the pepper robot and required some functionalities that weren't implemented in the current version of the driver.

This PR is based on #56 and includes #65 as well.

Here a list of the added functionality:

* Most of the output of the people perception components published together with gaze analysis and the waving detection
* A battery publisher has been added that also includes the current charging status and if the hatch is open or not.
* A simple animation player that either accepts the whole path of the animation or a tag as a string on a topic
* Sound source localisation
* Basic functionality of the behaviour manager to start and stop apps and query which apps are installed and running.

Additionally, it also contains a few commits of @nlyubova  regarding distortion and colour spaces. All this currently relies on the `nao_interaction_msgs` package which can be found in my fork: https://github.com/cdondrup/nao_interaction (didn't want to open a PR for that because I don't think this has a chance of being merged as it currently is ;) )

This PR is not really meant to be merged directly as it might introduce too many untested changes but should mainly serve to show what we are currently working on in case people are interested. I am more than happy about comments and if there is any interest I am of course happy to restructure for a possible merge so we can keep a cleaner commit history.

All this has been tested by @nlyubova and myself on pepper but not on NAO.
