### PR TITLE
[ros_env.hpp] delete std::getenv(ROS_NAMESPACE)

### DIFF
--- a/launch/naoqi_driver.launch
+++ b/launch/naoqi_driver.launch
@@ -4,7 +4,7 @@
   <arg name="nao_port"          default="$(optenv NAO_PORT 9559)" />
   <arg name="roscore_ip"        default="127.0.0.1" />
   <arg name="network_interface" default="eth0" />
-
-  <node pkg="naoqi_driver" type="naoqi_driver_node" name="naoqi_driver" required="true" args="--qi-url=tcp://$(arg nao_ip):$(arg nao_port) --roscore_ip=$(arg roscore_ip) --network_interface=$(arg network_interface)" output="screen" />
+  <arg name="namespace" default="$(optenv ROS_NAMESPACE naoqi_driver_node)" />
+  <node pkg="naoqi_driver" type="naoqi_driver_node" name="naoqi_driver" required="true" args="--qi-url=tcp://$(arg nao_ip):$(arg nao_port) --roscore_ip=$(arg roscore_ip) --network_interface=$(arg network_interface) --namespace=$(arg namespace)" output="screen" />
 
 </launch>

--- a/launch/naoqi_driver.launch
+++ b/launch/naoqi_driver.launch
@@ -4,7 +4,7 @@
   <arg name="nao_port"          default="$(optenv NAO_PORT 9559)" />
   <arg name="roscore_ip"        default="127.0.0.1" />
   <arg name="network_interface" default="eth0" />
-  <arg name="namespace" default="$(optenv ROS_NAMESPACE naoqi_driver_node)" />
+  <arg name="namespace" default="naoqi_driver_node" />
   <node pkg="naoqi_driver" type="naoqi_driver_node" name="naoqi_driver" required="true" args="--qi-url=tcp://$(arg nao_ip):$(arg nao_port) --roscore_ip=$(arg roscore_ip) --network_interface=$(arg network_interface) --namespace=$(arg namespace)" output="screen" />
 
 </launch>

--- a/src/ros_env.hpp
+++ b/src/ros_env.hpp
@@ -89,7 +89,7 @@ static void setMasterURI( const std::string& uri, const std::string& network_int
   remap["__master"] = uri;
   remap["__ip"] = ::naoqi::ros_env::getROSIP(network_interface);
   // init ros without a sigint-handler in order to shutdown correctly by naoqi
-  ros::init(remap, std::string("naoqi_driver_node"), ros::init_options::NoSigintHandler);
+  ros::init( remap, (::naoqi::ros_env::getPrefix()) , ros::init_options::NoSigintHandler );
   // to prevent shutdown based on no existing nodehandle
   ros::start();
 

--- a/src/ros_env.hpp
+++ b/src/ros_env.hpp
@@ -89,8 +89,7 @@ static void setMasterURI( const std::string& uri, const std::string& network_int
   remap["__master"] = uri;
   remap["__ip"] = ::naoqi::ros_env::getROSIP(network_interface);
   // init ros without a sigint-handler in order to shutdown correctly by naoqi
-  const char* ns_env = std::getenv("ROS_NAMESPACE");
-  ros::init( remap, (ns_env==NULL)?(std::string("naoqi_driver_node")):(::naoqi::ros_env::getPrefix()) , ros::init_options::NoSigintHandler );
+  ros::init(remap, std::string("naoqi_driver_node"), ros::init_options::NoSigintHandler);
   // to prevent shutdown based on no existing nodehandle
   ros::start();
 


### PR DESCRIPTION
Hi, 
I encountered the same issue as  https://github.com/ros-naoqi/pepper_robot/issues/35.
My environment is ubuntu 16.04, ros kinetic, naoqi 2.4.3.28.
I use source of naoqi_driver and pepper_robot package.

If there are any comments, please let me know.

```
roslaunch pepper_bringup pepper_full.launch network_interface:=enp0s25
rosnode list
```
=> 
```
/pepper_robot/pepper_robot/camera/bottom_rectify_color
/pepper_robot/pepper_robot/camera/camera_nodelet_manager
/pepper_robot/pepper_robot/camera/depth_metric
/pepper_robot/pepper_robot/camera/depth_metric_rect
/pepper_robot/pepper_robot/camera/depth_rectify_depth
/pepper_robot/pepper_robot/camera/depth_registered_hw_metric_rect
/pepper_robot/pepper_robot/camera/depth_registered_metric
/pepper_robot/pepper_robot/camera/depth_registered_rectify_depth
/pepper_robot/pepper_robot/camera/depth_registered_sw_metric_rect
/pepper_robot/pepper_robot/camera/front_rectify_color
/pepper_robot/pepper_robot/camera/ir_rectify_ir
/pepper_robot/pepper_robot/camera/points_xyzrgb_hw_registered
/pepper_robot/pepper_robot/camera/points_xyzrgb_sw_registered
/pepper_robot/pepper_robot/camera/register_depth_front
/pepper_robot/pepper_robot/naoqi_driver_node (This node name is modified)
/pepper_robot/pepper_robot/pose/pose_controller
/pepper_robot/pepper_robot/pose/pose_manager
/rosout
```
From #73, I learned that we can set ROS_NAMESPACE as a environmental variable, but in this case, we have to change the codes to use ```std::getenv(ROS_NAMESPACE)```. 
(I didn't know how to change them...)