### PR TITLE
Use kYUV422 images to increase the acquisition frequency 

### DIFF
--- a/src/converters/camera.hpp
+++ b/src/converters/camera.hpp
@@ -29,6 +29,11 @@
 */
 #include <image_transport/image_transport.h>
 
+/*
+* CV includes
+*/
+#include <opencv2/imgproc/imgproc.hpp>
+
 namespace naoqi
 {
 namespace converter
@@ -64,6 +69,7 @@ private:
   // goes along with colorspace_
   std::string msg_colorspace_;
   int cv_mat_type_;
+  cv::Mat cv_img_;
   // msg frame id
   std::string msg_frameid_;
   sensor_msgs::CameraInfo camera_info_;


### PR DESCRIPTION
Get kYUV422 images from the 2D cameras and convert them after to RGB. The image is lighter, it has 2 channels instead of 3. This allows getting VGA images from one camera at 15Hz instead of 9Hz using WiFi at 5GHz.

