### PR TITLE
add services for get and set language

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,8 @@ set(
 set(
   SERVICES_SRC
   src/services/robot_config.cpp
+  src/services/set_language.cpp
+  src/services/get_language.cpp
   )
 
 set(

--- a/src/helpers/driver_helpers.cpp
+++ b/src/helpers/driver_helpers.cpp
@@ -194,21 +194,20 @@ const naoqi_bridge_msgs::RobotInfo& getRobotInfo( const qi::SessionPtr& session 
   return robot_info;
 }
 
-/** Function that sets language for robot
+/** Function that sets language for a robot
  */
-static std_srvs::Empty& setLanguageLocal( const qi::SessionPtr& session, naoqi_bridge_msgs::SetLanguageRequest req)
+static std_srvs::Empty& setLanguageLocal( const qi::SessionPtr& session, naoqi_bridge_msgs::SetStringRequest req)
 {
   static qi::Url robot_url;
 
   robot_url = session->url();
 
-  // Get the robot type
   std::cout << "Receiving service call of setting speech language" << std::endl;
   qi::AnyObject p_text_to_speech = session->service("ALTextToSpeech");
-  p_text_to_speech.call<void>("setLanguage", req.language);
+  p_text_to_speech.call<void>("setLanguage", req.data);
 }
 
-const bool& setLanguage( const qi::SessionPtr& session, naoqi_bridge_msgs::SetLanguageRequest req)
+const bool& setLanguage( const qi::SessionPtr& session, naoqi_bridge_msgs::SetStringRequest req)
 {
   try{
     setLanguageLocal(session, req);
@@ -219,7 +218,7 @@ const bool& setLanguage( const qi::SessionPtr& session, naoqi_bridge_msgs::SetLa
   }
 }
 
-/** Function that gets language set at robot
+/** Function that gets language set to a robot
  */
   static std::string& getLanguageLocal( const qi::SessionPtr& session)
 {
@@ -228,14 +227,13 @@ const bool& setLanguage( const qi::SessionPtr& session, naoqi_bridge_msgs::SetLa
 
   robot_url = session->url();
 
-  // Get the robot type
   std::cout << "Receiving service call of getting speech language" << std::endl;
   qi::AnyObject p_text_to_speech = session->service("ALTextToSpeech");
   language = p_text_to_speech.call<std::string>("getLanguage");
   return language;
 }
 
-  const std::string& getLanguage( const qi::SessionPtr& session, naoqi_bridge_msgs::GetLanguageRequest req)
+  const std::string& getLanguage( const qi::SessionPtr& session, naoqi_bridge_msgs::GetStringRequest req)
 {
   std::string language;
   try{

--- a/src/helpers/driver_helpers.cpp
+++ b/src/helpers/driver_helpers.cpp
@@ -196,53 +196,31 @@ const naoqi_bridge_msgs::RobotInfo& getRobotInfo( const qi::SessionPtr& session 
 
 /** Function that sets language for a robot
  */
-static std_srvs::Empty& setLanguageLocal( const qi::SessionPtr& session, naoqi_bridge_msgs::SetStringRequest req)
+bool& setLanguage( const qi::SessionPtr& session, naoqi_bridge_msgs::SetStringRequest req)
 {
-  static qi::Url robot_url;
-
-  robot_url = session->url();
-
+  static bool success;
   std::cout << "Receiving service call of setting speech language" << std::endl;
-  qi::AnyObject p_text_to_speech = session->service("ALTextToSpeech");
-  p_text_to_speech.call<void>("setLanguage", req.data);
-}
-
-const bool& setLanguage( const qi::SessionPtr& session, naoqi_bridge_msgs::SetStringRequest req)
-{
   try{
-    setLanguageLocal(session, req);
-    return true;
+    qi::AnyObject p_text_to_speech = session->service("ALTextToSpeech");
+    p_text_to_speech.call<void>("setLanguage", req.data);
+    success = true;
+    return success;
   }
   catch(const std::exception& e){
-    return false;
+    success = false;
+    return success;
   }
 }
 
 /** Function that gets language set to a robot
  */
-  static std::string& getLanguageLocal( const qi::SessionPtr& session)
+std::string& getLanguage( const qi::SessionPtr& session )
 {
-  static qi::Url robot_url;
   static std::string language;
-
-  robot_url = session->url();
-
   std::cout << "Receiving service call of getting speech language" << std::endl;
   qi::AnyObject p_text_to_speech = session->service("ALTextToSpeech");
   language = p_text_to_speech.call<std::string>("getLanguage");
   return language;
-}
-
-  const std::string& getLanguage( const qi::SessionPtr& session, naoqi_bridge_msgs::GetStringRequest req)
-{
-  std::string language;
-  try{
-    language = getLanguageLocal(session);
-    return language;
-  }
-  catch(const std::exception& e){
-    return language;
-  }
 }
 
 } // driver

--- a/src/helpers/driver_helpers.cpp
+++ b/src/helpers/driver_helpers.cpp
@@ -194,6 +194,59 @@ const naoqi_bridge_msgs::RobotInfo& getRobotInfo( const qi::SessionPtr& session 
   return robot_info;
 }
 
+/** Function that sets language for robot
+ */
+static std_srvs::Empty& setLanguageLocal( const qi::SessionPtr& session, naoqi_bridge_msgs::SetLanguageRequest req)
+{
+  static qi::Url robot_url;
+
+  robot_url = session->url();
+
+  // Get the robot type
+  std::cout << "Receiving service call of setting speech language" << std::endl;
+  qi::AnyObject p_text_to_speech = session->service("ALTextToSpeech");
+  p_text_to_speech.call<void>("setLanguage", req.language);
+}
+
+const bool& setLanguage( const qi::SessionPtr& session, naoqi_bridge_msgs::SetLanguageRequest req)
+{
+  try{
+    setLanguageLocal(session, req);
+    return true;
+  }
+  catch(const std::exception& e){
+    return false;
+  }
+}
+
+/** Function that gets language set at robot
+ */
+  static std::string& getLanguageLocal( const qi::SessionPtr& session)
+{
+  static qi::Url robot_url;
+  static std::string language;
+
+  robot_url = session->url();
+
+  // Get the robot type
+  std::cout << "Receiving service call of getting speech language" << std::endl;
+  qi::AnyObject p_text_to_speech = session->service("ALTextToSpeech");
+  language = p_text_to_speech.call<std::string>("getLanguage");
+  return language;
+}
+
+  const std::string& getLanguage( const qi::SessionPtr& session, naoqi_bridge_msgs::GetLanguageRequest req)
+{
+  std::string language;
+  try{
+    language = getLanguageLocal(session);
+    return language;
+  }
+  catch(const std::exception& e){
+    return language;
+  }
+}
+
 } // driver
 } // helpers
 } // naoqi

--- a/src/helpers/driver_helpers.hpp
+++ b/src/helpers/driver_helpers.hpp
@@ -25,10 +25,6 @@
 
 #include <naoqi_bridge_msgs/SetString.h>
 
-#include <naoqi_bridge_msgs/GetString.h>
-
-#include <std_srvs/Empty.h>
-
 #include <qi/applicationsession.hpp>
 
 namespace naoqi
@@ -42,9 +38,9 @@ const robot::Robot& getRobot( const qi::SessionPtr& session );
 
 const naoqi_bridge_msgs::RobotInfo& getRobotInfo( const qi::SessionPtr& session );
 
-const bool& setLanguage( const qi::SessionPtr& session, naoqi_bridge_msgs::SetStringRequest req );
+bool& setLanguage( const qi::SessionPtr& session, naoqi_bridge_msgs::SetStringRequest req );
 
-const std::string& getLanguage( const qi::SessionPtr& session, naoqi_bridge_msgs::GetStringRequest req );
+std::string& getLanguage( const qi::SessionPtr& session );
 
 } // driver
 } // helpers

--- a/src/helpers/driver_helpers.hpp
+++ b/src/helpers/driver_helpers.hpp
@@ -23,9 +23,9 @@
 
 #include <naoqi_bridge_msgs/RobotInfo.h>
 
-#include <naoqi_bridge_msgs/SetLanguage.h>
+#include <naoqi_bridge_msgs/SetString.h>
 
-#include <naoqi_bridge_msgs/GetLanguage.h>
+#include <naoqi_bridge_msgs/GetString.h>
 
 #include <std_srvs/Empty.h>
 
@@ -42,9 +42,9 @@ const robot::Robot& getRobot( const qi::SessionPtr& session );
 
 const naoqi_bridge_msgs::RobotInfo& getRobotInfo( const qi::SessionPtr& session );
 
-const bool& setLanguage( const qi::SessionPtr& session, naoqi_bridge_msgs::SetLanguageRequest req );
+const bool& setLanguage( const qi::SessionPtr& session, naoqi_bridge_msgs::SetStringRequest req );
 
-const std::string& getLanguage( const qi::SessionPtr& session, naoqi_bridge_msgs::GetLanguageRequest req );
+const std::string& getLanguage( const qi::SessionPtr& session, naoqi_bridge_msgs::GetStringRequest req );
 
 } // driver
 } // helpers

--- a/src/helpers/driver_helpers.hpp
+++ b/src/helpers/driver_helpers.hpp
@@ -23,6 +23,12 @@
 
 #include <naoqi_bridge_msgs/RobotInfo.h>
 
+#include <naoqi_bridge_msgs/SetLanguage.h>
+
+#include <naoqi_bridge_msgs/GetLanguage.h>
+
+#include <std_srvs/Empty.h>
+
 #include <qi/applicationsession.hpp>
 
 namespace naoqi
@@ -35,6 +41,10 @@ namespace driver
 const robot::Robot& getRobot( const qi::SessionPtr& session );
 
 const naoqi_bridge_msgs::RobotInfo& getRobotInfo( const qi::SessionPtr& session );
+
+const bool& setLanguage( const qi::SessionPtr& session, naoqi_bridge_msgs::SetLanguageRequest req );
+
+const std::string& getLanguage( const qi::SessionPtr& session, naoqi_bridge_msgs::GetLanguageRequest req );
 
 } // driver
 } // helpers

--- a/src/naoqi_driver.cpp
+++ b/src/naoqi_driver.cpp
@@ -69,6 +69,8 @@
  * SERVICES
  */
 #include "services/robot_config.hpp"
+#include "services/set_language.hpp"
+#include "services/get_language.hpp"
 
 /*
  * RECORDERS
@@ -889,6 +891,8 @@ void Driver::registerService( service::Service srv )
 void Driver::registerDefaultServices()
 {
   registerService( boost::make_shared<service::RobotConfigService>("robot config service", "/naoqi_driver/get_robot_config", sessionPtr_) );
+  registerService( boost::make_shared<service::SetLanguageService>("set language service", "/naoqi_driver/set_language", sessionPtr_) );
+  registerService( boost::make_shared<service::GetLanguageService>("get language service", "/naoqi_driver/get_language", sessionPtr_) );
 }
 
 std::vector<std::string> Driver::getAvailableConverters()

--- a/src/services/get_language.cpp
+++ b/src/services/get_language.cpp
@@ -36,7 +36,7 @@ void GetLanguageService::reset( ros::NodeHandle& nh )
 
 bool GetLanguageService::callback( naoqi_bridge_msgs::GetStringRequest& req, naoqi_bridge_msgs::GetStringResponse& resp )
 {
-  resp.data = helpers::driver::getLanguage(session_, req);
+  resp.data = helpers::driver::getLanguage(session_);
   return true;
 }
 

--- a/src/services/get_language.cpp
+++ b/src/services/get_language.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 Aldebaran
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include "get_language.hpp"
+#include "../helpers/driver_helpers.hpp"
+
+namespace naoqi
+{
+namespace service
+{
+
+GetLanguageService::GetLanguageService( const std::string& name, const std::string& topic, const qi::SessionPtr& session )
+  : name_(name),
+  topic_(topic),
+  session_(session)
+{}
+
+void GetLanguageService::reset( ros::NodeHandle& nh )
+{
+  service_ = nh.advertiseService(topic_, &GetLanguageService::callback, this);
+}
+
+bool GetLanguageService::callback( naoqi_bridge_msgs::GetLanguageRequest& req, naoqi_bridge_msgs::GetLanguageResponse& resp )
+{
+  resp.language = helpers::driver::getLanguage(session_, req);
+  return true;
+}
+
+
+}
+}

--- a/src/services/get_language.cpp
+++ b/src/services/get_language.cpp
@@ -34,9 +34,9 @@ void GetLanguageService::reset( ros::NodeHandle& nh )
   service_ = nh.advertiseService(topic_, &GetLanguageService::callback, this);
 }
 
-bool GetLanguageService::callback( naoqi_bridge_msgs::GetLanguageRequest& req, naoqi_bridge_msgs::GetLanguageResponse& resp )
+bool GetLanguageService::callback( naoqi_bridge_msgs::GetStringRequest& req, naoqi_bridge_msgs::GetStringResponse& resp )
 {
-  resp.language = helpers::driver::getLanguage(session_, req);
+  resp.data = helpers::driver::getLanguage(session_, req);
   return true;
 }
 

--- a/src/services/get_language.hpp
+++ b/src/services/get_language.hpp
@@ -24,7 +24,7 @@
 #include <ros/node_handle.h>
 #include <ros/service_server.h>
 
-#include <naoqi_bridge_msgs/GetLanguage.h>
+#include <naoqi_bridge_msgs/GetString.h>
 #include <qi/session.hpp>
 
 namespace naoqi
@@ -51,7 +51,7 @@ public:
 
   void reset( ros::NodeHandle& nh );
 
-  bool callback( naoqi_bridge_msgs::GetLanguageRequest& req, naoqi_bridge_msgs::GetLanguageResponse& resp );
+  bool callback( naoqi_bridge_msgs::GetStringRequest& req, naoqi_bridge_msgs::GetStringResponse& resp );
 
 
 private:

--- a/src/services/get_language.hpp
+++ b/src/services/get_language.hpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017 Aldebaran
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+
+#ifndef GET_LANGUAGE_SERVICE_HPP
+#define GET_LANGUAGE_SERVICE_HPP
+
+#include <iostream>
+
+#include <ros/node_handle.h>
+#include <ros/service_server.h>
+
+#include <naoqi_bridge_msgs/GetLanguage.h>
+#include <qi/session.hpp>
+
+namespace naoqi
+{
+namespace service
+{
+
+class GetLanguageService
+{
+public:
+  GetLanguageService( const std::string& name, const std::string& topic, const qi::SessionPtr& session );
+
+  ~GetLanguageService(){};
+
+  std::string name() const
+  {
+    return name_;
+  }
+
+  std::string topic() const
+  {
+    return topic_;
+  }
+
+  void reset( ros::NodeHandle& nh );
+
+  bool callback( naoqi_bridge_msgs::GetLanguageRequest& req, naoqi_bridge_msgs::GetLanguageResponse& resp );
+
+
+private:
+  const std::string name_;
+  const std::string topic_;
+
+  const qi::SessionPtr& session_;
+  ros::ServiceServer service_;
+};
+
+} // service
+} // naoqi
+#endif

--- a/src/services/set_language.cpp
+++ b/src/services/set_language.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 Aldebaran
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include "set_language.hpp"
+#include "../helpers/driver_helpers.hpp"
+
+namespace naoqi
+{
+namespace service
+{
+
+SetLanguageService::SetLanguageService( const std::string& name, const std::string& topic, const qi::SessionPtr& session )
+  : name_(name),
+  topic_(topic),
+  session_(session)
+{}
+
+void SetLanguageService::reset( ros::NodeHandle& nh )
+{
+  service_ = nh.advertiseService(topic_, &SetLanguageService::callback, this);
+}
+
+bool SetLanguageService::callback( naoqi_bridge_msgs::SetLanguageRequest& req, naoqi_bridge_msgs::SetLanguageResponse& resp )
+{
+  resp.success = helpers::driver::setLanguage(session_, req);
+  return true;
+}
+
+
+}
+}

--- a/src/services/set_language.cpp
+++ b/src/services/set_language.cpp
@@ -34,7 +34,7 @@ void SetLanguageService::reset( ros::NodeHandle& nh )
   service_ = nh.advertiseService(topic_, &SetLanguageService::callback, this);
 }
 
-bool SetLanguageService::callback( naoqi_bridge_msgs::SetLanguageRequest& req, naoqi_bridge_msgs::SetLanguageResponse& resp )
+bool SetLanguageService::callback( naoqi_bridge_msgs::SetStringRequest& req, naoqi_bridge_msgs::SetStringResponse& resp )
 {
   resp.success = helpers::driver::setLanguage(session_, req);
   return true;

--- a/src/services/set_language.hpp
+++ b/src/services/set_language.hpp
@@ -24,7 +24,7 @@
 #include <ros/node_handle.h>
 #include <ros/service_server.h>
 
-#include <naoqi_bridge_msgs/SetLanguage.h>
+#include <naoqi_bridge_msgs/SetString.h>
 #include <qi/session.hpp>
 
 namespace naoqi
@@ -51,7 +51,7 @@ public:
 
   void reset( ros::NodeHandle& nh );
 
-  bool callback( naoqi_bridge_msgs::SetLanguageRequest& req, naoqi_bridge_msgs::SetLanguageResponse& resp );
+  bool callback( naoqi_bridge_msgs::SetStringRequest& req, naoqi_bridge_msgs::SetStringResponse& resp );
 
 
 private:

--- a/src/services/set_language.hpp
+++ b/src/services/set_language.hpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017 Aldebaran
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+
+#ifndef SET_LANGUAGE_SERVICE_HPP
+#define SET_LANGUAGE_SERVICE_HPP
+
+#include <iostream>
+
+#include <ros/node_handle.h>
+#include <ros/service_server.h>
+
+#include <naoqi_bridge_msgs/SetLanguage.h>
+#include <qi/session.hpp>
+
+namespace naoqi
+{
+namespace service
+{
+
+class SetLanguageService
+{
+public:
+  SetLanguageService( const std::string& name, const std::string& topic, const qi::SessionPtr& session );
+
+  ~SetLanguageService(){};
+
+  std::string name() const
+  {
+    return name_;
+  }
+
+  std::string topic() const
+  {
+    return topic_;
+  }
+
+  void reset( ros::NodeHandle& nh );
+
+  bool callback( naoqi_bridge_msgs::SetLanguageRequest& req, naoqi_bridge_msgs::SetLanguageResponse& resp );
+
+
+private:
+  const std::string name_;
+  const std::string topic_;
+
+  const qi::SessionPtr& session_;
+  ros::ServiceServer service_;
+};
+
+} // service
+} // naoqi
+#endif


### PR DESCRIPTION
reference: http://doc.aldebaran.com/2-4/naoqi/audio/altexttospeech-api.html#altexttospeech-api
```ALTextToSpeechProxy::setLanguage``` and ```ALTextToSpeechProxy::getLanguage```

requires: https://github.com/ros-naoqi/naoqi_bridge_msgs/pull/32

I tried it with pepper, naoqi 2.5.5.5, ros indigo 

```
roslaunch naoqi_driver naoqi_driver.launch
kochigami@kochigami-ThinkPad-T450:~/catkin_ws/src/naoqi_driver/src/services$ rosservice list | grep lang
/naoqi_driver/get_language
/naoqi_driver/set_language

kochigami@kochigami-ThinkPad-T450:~/catkin_ws/src/naoqi_driver/src/services$ rosservice call /naoqi_driver/set_language "language: 'English'" 
success: True

kochigami@kochigami-ThinkPad-T450:~/catkin_ws/src/naoqi_driver/src/services$ rosservice call /naoqi_driver/get_language "{}" 
language: English
```