### PR TITLE
disable logs as default (reference #68)

### DIFF
--- a/share/boot_config.json
+++ b/share/boot_config.json
@@ -37,7 +37,7 @@
     },
     "logs":
     {
-      "enabled"       : true,
+      "enabled"       : false,
       "frequency"     : 1
     },
     "diag":


### PR DESCRIPTION
My environment is ubuntu 14.04, ros indigo, naoqi 2.5.5.5

After updating my pepper (Naoqi 2.4 => 2.5), I saw a lot of log message warnings.
Based on #68 discussion, I modified default value of logs as ```false```.
Now, these disappeared and I just send a pull-request of it. 



  