### PR TITLE
C-style comments are not syntactically correct in JSON

### DIFF
--- a/share/boot_config.json
+++ b/share/boot_config.json
@@ -1,4 +1,3 @@
-/* QQVGA = 0, QVGA = 1, VGA =2 */
 {
   "converters":
   {

--- a/share/boot_config.json
+++ b/share/boot_config.json
@@ -1,4 +1,5 @@
 {
+  "_comment": "QQVGA = 0, QVGA = 1, VGA = 2",
   "converters":
   {
     "front_camera":


### PR DESCRIPTION
The JSON grammar does not accept C (/* */) or C++ (//) comments.

See:
- http://www.json.org/
- http://www.ietf.org/rfc/rfc7159.txt
- https://stackoverflow.com/a/4183018