### PR TITLE
(wip) add chest button topic (pressed or not)

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -26,6 +26,7 @@
   <build_depend>rosbag_storage</build_depend>
   <build_depend>rosconsole</build_depend>
   <build_depend>rosgraph_msgs</build_depend>
+  <build_depend>std_msgs</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>tf2_geometry_msgs</build_depend>
   <build_depend>tf2_msgs</build_depend>

--- a/share/boot_config.json
+++ b/share/boot_config.json
@@ -86,6 +86,10 @@
     {
       "enabled"       : true
     },
+    "chest_button":
+    {
+      "enabled"       : true
+    },
     "odom":
     {
       "enabled"       : true,

--- a/src/converters/touch.cpp
+++ b/src/converters/touch.cpp
@@ -65,6 +65,7 @@ void TouchEventConverter<T>::callAll(const std::vector<message_actions::MessageA
 template class TouchEventConverter<naoqi_bridge_msgs::Bumper>;
 template class TouchEventConverter<naoqi_bridge_msgs::HandTouch>;
 template class TouchEventConverter<naoqi_bridge_msgs::HeadTouch>;
+template class TouchEventConverter<std_msgs::Bool>;
 }
 
 }

--- a/src/converters/touch.hpp
+++ b/src/converters/touch.hpp
@@ -30,6 +30,7 @@
 #include <naoqi_bridge_msgs/Bumper.h>
 #include <naoqi_bridge_msgs/HandTouch.h>
 #include <naoqi_bridge_msgs/HeadTouch.h>
+#include <std_msgs/Bool.h>
 
 /*
 * ALDEBARAN includes

--- a/src/event/touch.cpp
+++ b/src/event/touch.cpp
@@ -242,9 +242,22 @@ void TouchEventRegister<T>::touchCallbackMessage(std::string &key, bool &state, 
   }
 }
 
+template<class T>
+void TouchEventRegister<T>::touchCallbackMessage(std::string &key, bool &state, std_msgs::Bool &msg)
+{
+  int i = 0;
+  for(std::vector<std::string>::const_iterator it = keys_.begin(); it != keys_.end(); ++it, ++i)
+  {
+    if ( key == it->c_str() ) {
+      msg.data = state;
+    }
+  }
+}
+
 // http://stackoverflow.com/questions/8752837/undefined-reference-to-template-class-constructor
 template class TouchEventRegister<naoqi_bridge_msgs::Bumper>;
 template class TouchEventRegister<naoqi_bridge_msgs::HandTouch>;
 template class TouchEventRegister<naoqi_bridge_msgs::HeadTouch>;
+template class TouchEventRegister<std_msgs::Bool>;
 
 }//namespace

--- a/src/event/touch.hpp
+++ b/src/event/touch.hpp
@@ -31,6 +31,7 @@
 #include <naoqi_bridge_msgs/Bumper.h>
 #include <naoqi_bridge_msgs/HandTouch.h>
 #include <naoqi_bridge_msgs/HeadTouch.h>
+#include <std_msgs/Bool.h>
 
 #include <naoqi_driver/tools.hpp>
 #include <naoqi_driver/recorder/globalrecorder.hpp>
@@ -82,6 +83,7 @@ public:
   void touchCallbackMessage(std::string &key, bool &state, naoqi_bridge_msgs::Bumper &msg);
   void touchCallbackMessage(std::string &key, bool &state, naoqi_bridge_msgs::HandTouch &msg);
   void touchCallbackMessage(std::string &key, bool &state, naoqi_bridge_msgs::HeadTouch &msg);
+  void touchCallbackMessage(std::string &key, bool &state, std_msgs::Bool &msg);
   
 
 private:
@@ -129,6 +131,12 @@ public:
   HandTouchEventRegister( const std::string& name, const std::vector<std::string> keys, const float& frequency, const qi::SessionPtr& session ) : TouchEventRegister<naoqi_bridge_msgs::HandTouch>(name, keys, frequency, session) {}
 };
 
+class ChestTouchEventRegister: public TouchEventRegister<std_msgs::Bool>
+{
+public:
+  ChestTouchEventRegister( const std::string& name, const std::vector<std::string> keys, const float& frequency, const qi::SessionPtr& session ) : TouchEventRegister<std_msgs::Bool>(name, keys, frequency, session) {}
+};
+
 //QI_REGISTER_OBJECT(BumperEventRegister, touchCallback)
 //QI_REGISTER_OBJECT(HeadTouchEventRegister, touchCallback)
 
@@ -155,6 +163,14 @@ static bool _qiregisterTouchEventRegisterHeadTouch() {
   return true;
   }
 static bool BOOST_PP_CAT(__qi_registration, __LINE__) = _qiregisterTouchEventRegisterHeadTouch();
+
+static bool _qiregisterTouchEventRegisterChestTouch() {
+  ::qi::ObjectTypeBuilder<TouchEventRegister<std_msgs::Bool> > b;
+  QI_VAARGS_APPLY(__QI_REGISTER_ELEMENT, TouchEventRegister<std_msgs::Bool>, touchCallback)
+    b.registerType();
+  return true;
+  }
+static bool BOOST_PP_CAT(__qi_registration, __LINE__) = _qiregisterTouchEventRegisterChestTouch();
 
 } //naoqi
 

--- a/src/naoqi_driver.cpp
+++ b/src/naoqi_driver.cpp
@@ -591,6 +591,7 @@ void Driver::registerDefaultConverter()
   bool bumper_enabled                 = boot_config_.get( "converters.bumper.enabled", true);
   bool hand_enabled                   = boot_config_.get( "converters.touch_hand.enabled", true);
   bool head_enabled                   = boot_config_.get( "converters.touch_head.enabled", true);
+  bool chest_enabled                  = boot_config_.get( "converters.chest_button.enabled", true);
   /*
    * The info converter will be called once after it was added to the priority queue. Once it is its turn to be called, its
    * callAll method will be triggered (because InfoPublisher is considered to always have subscribers, isSubscribed always
@@ -831,6 +832,21 @@ void Driver::registerDefaultConverter()
     }
     if (publish_enabled_) {
       event_map_.find("head_touch")->second.isPublishing(true);
+    }
+  }
+
+  if ( chest_enabled )
+  {
+    std::vector<std::string> chest_touch_events;
+    chest_touch_events.push_back("ChestButtonPressed");
+    boost::shared_ptr<ChestTouchEventRegister> event_register =
+      boost::make_shared<ChestTouchEventRegister>( "chest_touch", chest_touch_events, 0, sessionPtr_ );
+    insertEventConverter("chest_touch", event_register);
+    if (keep_looping) {
+      event_map_.find("chest_touch")->second.startProcess();
+    }
+    if (publish_enabled_) {
+      event_map_.find("chest_touch")->second.isPublishing(true);
     }
   }
 


### PR DESCRIPTION
This change enables us to publish a topic based on the `ChestButtonPressed` event.
ref: http://doc.aldebaran.com/2-5/naoqi/sensors/alchestbutton-api.html#alchestbutton-api

I will create a message like `ChestButton.msg` in `naoqi_bridge_msgs` later.
I will update this later.

confirmed with;
- [ ] Pepper (NAOqi 2.5.5.5) + ros indigo 
- [ ] Pepper (NAOqi 2.5.5.5) + ros kinetic 
- [ ] NAO (NAOqi 2.1.4) + ros indigo
- [ ] NAO (NAOqi 2.1.4) + ros kinetic