### PR TITLE
Missing tf2 include and tf2 exception type

### DIFF
--- a/src/converters/joint_state.hpp
+++ b/src/converters/joint_state.hpp
@@ -30,6 +30,7 @@
 */
 #include <urdf/model.h>
 #include <sensor_msgs/JointState.h>
+#include <tf2_ros/buffer.h>
 #include <robot_state_publisher/robot_state_publisher.h>
 
 namespace naoqi

--- a/src/converters/nao_footprint.hpp
+++ b/src/converters/nao_footprint.hpp
@@ -52,7 +52,7 @@ inline void addBaseFootprint( boost::shared_ptr<tf2_ros::Buffer> tf2_buffer, std
     tf_odom_to_left_foot  = tf2_buffer->lookupTransform("odom", "l_sole",    time );
     tf_odom_to_right_foot = tf2_buffer->lookupTransform("odom", "r_sole",    time );
     tf_odom_to_base       = tf2_buffer->lookupTransform("odom", "base_link", time );
-  } catch (const tf::TransformException& ex){
+  } catch (const tf2::TransformException& ex){
     ROS_ERROR("NAO Footprint error %s",ex.what());
     return ;
   }


### PR DESCRIPTION
This fixes two issues that will be present in ROS Melodic due to ros/robot_state_publisher#82.

Currently `<robot_state_publisher/robot_state_publisher.h>` includes `<tf/tf.h>` which includes `<tf2_ros/buffer.h>` and `<tf/exceptions.h>`. Starting in ROS Melodic robot_state_publisher won't include any tf 1 headers.