### PR TITLE
add naoqi_driver initialized message

### DIFF
--- a/include/naoqi_driver/service/service.hpp
+++ b/include/naoqi_driver/service/service.hpp
@@ -60,6 +60,7 @@ public:
   {
     std::cout << name() << " is resetting" << std::endl;
     srvPtr_->reset( nh );
+    std::cout << name() << " reset" << std::endl;
   }
 
   /**

--- a/src/external_registration.cpp
+++ b/src/external_registration.cpp
@@ -91,6 +91,7 @@ int main(int argc, char** argv)
     bs->init();
   }
 
+  std::cout << BOLDYELLOW << "naoqi_driver initialized" << RESETCOLOR << std::endl;
   app.run();
   bs->stopService();
   app.session()->close();

--- a/src/naoqi_driver.cpp
+++ b/src/naoqi_driver.cpp
@@ -890,9 +890,9 @@ void Driver::registerService( service::Service srv )
 
 void Driver::registerDefaultServices()
 {
-  registerService( boost::make_shared<service::RobotConfigService>("robot config service", "/naoqi_driver/get_robot_config", sessionPtr_) );
-  registerService( boost::make_shared<service::SetLanguageService>("set language service", "/naoqi_driver/set_language", sessionPtr_) );
-  registerService( boost::make_shared<service::GetLanguageService>("get language service", "/naoqi_driver/get_language", sessionPtr_) );
+  registerService( boost::make_shared<service::RobotConfigService>("get_robot_config", "/naoqi_driver/get_robot_config", sessionPtr_) );
+  registerService( boost::make_shared<service::SetLanguageService>("set_language", "/naoqi_driver/set_language", sessionPtr_) );
+  registerService( boost::make_shared<service::GetLanguageService>("get_language", "/naoqi_driver/get_language", sessionPtr_) );
 }
 
 std::vector<std::string> Driver::getAvailableConverters()
@@ -964,13 +964,11 @@ void Driver::setMasterURINet( const std::string& uri, const std::string& network
 
     for_each( subscriber::Subscriber& sub, subscribers_ )
     {
-      std::cout << "resetting subscriber " << sub.name() << std::endl;
       sub.reset( *nhPtr_ );
     }
 
     for_each( service::Service& srv, services_ )
     {
-      std::cout << "resetting service " << srv.name() << std::endl;
       srv.reset( *nhPtr_ );
     }
   }


### PR DESCRIPTION
added `naoqi_driver initialized` message when we launch `naoqi_driver.launch`

(The last sentence below)
```
 roslaunch naoqi_driver naoqi_driver.launch network_interface:=eth1
... logging to /home/kochigami/.ros/log/0b81b40c-4867-11e8-a3b9-507b9d20c4fb/roslaunch-kochigami-ThinkPad-T450-14823.log
Checking log directory for disk usage. This may take awhile.
Press Ctrl-C to interrupt
Done checking log file disk usage. Usage is <1GB.

started roslaunch server http://192.168.97.211:45371/

SUMMARY
========

PARAMETERS
 * /rosdistro: indigo
 * /rosversion: 1.11.21

NODES
  /
    naoqi_driver (naoqi_driver/naoqi_driver_node)

auto-starting new master
process[master]: started with pid [14835]
ROS_MASTER_URI=http://localhost:11311

setting /run_id to 0b81b40c-4867-11e8-a3b9-507b9d20c4fb
process[rosout-1]: started with pid [14849]
started core service [/rosout]
process[naoqi_driver-2]: started with pid [14866]
Receiving information about robot model
[W] 14866 qimessaging.remoteobject: Return signature might be incorrect depending on the value, from m to s
[W] 14866 qimessaging.remoteobject: Return signature might be incorrect depending on the value, from m to [[m]]
set prefix successfully to naoqi_driver
[I] 14866 qimessaging.session: Session listener created on tcp://0.0.0.0:0
[I] 14866 qimessaging.transportserver: TransportServer will listen on: tcp://192.168.97.211:44101
[I] 14866 qimessaging.transportserver: TransportServer will listen on: tcp://127.0.0.1:44101
using ip address: 127.0.0.1 @ eth1
found a catkin prefix /home/kochigami/catkin_ws/src/naoqi_driver/share/boot_config.json
load boot config from /home/kochigami/catkin_ws/src/naoqi_driver/share/boot_config.json
no camera information found for camera_source 3 and res: 1
found a catkin URDF /home/kochigami/catkin_ws/src/naoqi_driver/share/urdf/pepper.urdf
Audio Extractor: Start
RightBumperPressed
LeftBumperPressed
BackBumperPressed
ROS-Driver-RightBumperPressed : Start
HandRightBackTouched
HandRightLeftTouched
HandRightRightTouched
HandLeftBackTouched
HandLeftLeftTouched
HandLeftRightTouched
ROS-Driver-HandRightBackTouched : Start
FrontTactilTouched
MiddleTactilTouched
RearTactilTouched
ROS-Driver-FrontTactilTouched : Start
registered subscriber:	teleop
registered subscriber:	moveto
registered subscriber:	speech
nodehandle reset 
using master ip: http://127.0.0.1:11311
NOT going to re-register the converters
camera/bottom/image_raw is resetting
camera/bottom/image_raw reset
camera/depth/image_raw is resetting
camera/depth/image_raw reset
/diagnostics is resetting
/diagnostics reset
camera/front/image_raw is resetting
camera/front/image_raw reset
imu/base is resetting
imu/base reset
imu/torso is resetting
imu/torso reset
info is resetting
load robot description from file
info reset
camera/ir/image_raw is resetting
camera/ir/image_raw reset
/joint_states is resetting
/joint_states reset
laser is resetting
laser reset
odom is resetting
odom reset
sonar is resetting
sonar reset
resetting subscriber teleop
teleop is resetting
teleop reset
resetting subscriber moveto
moveto is resetting
moveto reset
resetting subscriber speech
speech is resetting
speech reset
resetting service robot config service
robot config service is resetting
resetting service set language service
set language service is resetting
resetting service get language service
get language service is resetting
naoqi_driver initialized 
```

I will change messages of service such as `get language service is resetting` to `get language service reset` like subscribers later.

reference: discussion in #104 