### PR TITLE
add play audio file service

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ set(
   src/services/robot_config.cpp
   src/services/set_language.cpp
   src/services/get_language.cpp
+  src/services/play_audio_file.cpp
   )
 
 set(

--- a/CMakeLists_catkin.txt
+++ b/CMakeLists_catkin.txt
@@ -11,6 +11,7 @@ find_package(catkin COMPONENTS
   image_transport
   kdl_parser
   naoqi_bridge_msgs
+  nao_interaction_msgs
   naoqi_libqi
   naoqi_libqicore
   robot_state_publisher

--- a/package.xml
+++ b/package.xml
@@ -19,6 +19,7 @@
   <build_depend>image_transport</build_depend>
   <build_depend>kdl_parser</build_depend>
   <build_depend version_gte="0.0.4">naoqi_bridge_msgs</build_depend>
+  <build_depend>nao_interaction_msgs</build_depend>
   <build_depend>naoqi_libqi</build_depend>
   <build_depend>naoqi_libqicore</build_depend>
   <build_depend>orocos_kdl</build_depend>
@@ -27,6 +28,7 @@
   <build_depend>rosconsole</build_depend>
   <build_depend>rosgraph_msgs</build_depend>
   <build_depend>sensor_msgs</build_depend>
+  <build_depend>std_msgs</build_depend>
   <build_depend>tf2_geometry_msgs</build_depend>
   <build_depend>tf2_msgs</build_depend>
   <build_depend>tf2_ros</build_depend>

--- a/src/helpers/driver_helpers.cpp
+++ b/src/helpers/driver_helpers.cpp
@@ -223,6 +223,20 @@ std::string& getLanguage( const qi::SessionPtr& session )
   return language;
 }
 
+/** Function that plays audio file
+ */
+std_msgs::Empty& playAudioFile( const qi::SessionPtr& session, nao_interaction_msgs::AudioPlaybackRequest req)
+{
+  std::cout << "Receiving service call of playing audio file" << std::endl;
+  try{
+    qi::AnyObject p_audio_player = session->service("ALAudioPlayer");
+    p_audio_player.call<void>("playFile", "/home/nao/" + req.file_path.data);
+  }
+  catch(const std::exception& e){
+    std::cout << "Error in executing service of playing audio file" << std::endl;
+  }
+}
+
 } // driver
 } // helpers
 } // naoqi

--- a/src/helpers/driver_helpers.hpp
+++ b/src/helpers/driver_helpers.hpp
@@ -23,9 +23,14 @@
 
 #include <naoqi_bridge_msgs/RobotInfo.h>
 
+#include <std_msgs/Empty.h>
+
 #include <naoqi_bridge_msgs/SetString.h>
 
+#include <nao_interaction_msgs/AudioPlayback.h>
+
 #include <qi/applicationsession.hpp>
+
 
 namespace naoqi
 {
@@ -41,6 +46,8 @@ const naoqi_bridge_msgs::RobotInfo& getRobotInfo( const qi::SessionPtr& session 
 bool& setLanguage( const qi::SessionPtr& session, naoqi_bridge_msgs::SetStringRequest req );
 
 std::string& getLanguage( const qi::SessionPtr& session );
+
+std_msgs::Empty& playAudioFile( const qi::SessionPtr& session, nao_interaction_msgs::AudioPlaybackRequest req);
 
 } // driver
 } // helpers

--- a/src/naoqi_driver.cpp
+++ b/src/naoqi_driver.cpp
@@ -71,6 +71,7 @@
 #include "services/robot_config.hpp"
 #include "services/set_language.hpp"
 #include "services/get_language.hpp"
+#include "services/play_audio_file.hpp"
 
 /*
  * RECORDERS
@@ -893,6 +894,7 @@ void Driver::registerDefaultServices()
   registerService( boost::make_shared<service::RobotConfigService>("get_robot_config", "/naoqi_driver/get_robot_config", sessionPtr_) );
   registerService( boost::make_shared<service::SetLanguageService>("set_language", "/naoqi_driver/set_language", sessionPtr_) );
   registerService( boost::make_shared<service::GetLanguageService>("get_language", "/naoqi_driver/get_language", sessionPtr_) );
+  registerService( boost::make_shared<service::PlayAudioFileService>("play audio file", "/naoqi_driver/play_audio_file", sessionPtr_) );
 }
 
 std::vector<std::string> Driver::getAvailableConverters()

--- a/src/services/play_audio_file.cpp
+++ b/src/services/play_audio_file.cpp
@@ -1,0 +1,28 @@
+#include "play_audio_file.hpp"
+#include "../helpers/driver_helpers.hpp"
+
+namespace naoqi
+{
+  namespace service
+  {
+
+    PlayAudioFileService::PlayAudioFileService( const std::string& name, const std::string& topic, const qi::SessionPtr& session )
+      : name_(name),
+	topic_(topic),
+	session_(session)
+    {}
+
+    void PlayAudioFileService::reset( ros::NodeHandle& nh )
+    {
+      service_ = nh.advertiseService(topic_, &PlayAudioFileService::callback, this);
+    }
+
+    bool PlayAudioFileService::callback( nao_interaction_msgs::AudioPlaybackRequest& req, nao_interaction_msgs::AudioPlaybackResponse& resp )
+    {
+      helpers::driver::playAudioFile(session_, req);
+      return true;
+    }
+
+
+  }
+}

--- a/src/services/play_audio_file.hpp
+++ b/src/services/play_audio_file.hpp
@@ -1,0 +1,49 @@
+#ifndef PLAY_AUDIO_FILE_SERVICE_HPP
+#define PLAY_AUDIO_FILE_SERVICE_HPP
+
+#include <iostream>
+
+#include <ros/node_handle.h>
+#include <ros/service_server.h>
+
+#include <nao_interaction_msgs/AudioPlayback.h>
+#include <qi/session.hpp>
+
+namespace naoqi
+{
+  namespace service
+  {
+
+    class PlayAudioFileService
+    {
+    public:
+      PlayAudioFileService( const std::string& name, const std::string& topic, const qi::SessionPtr& session );
+
+      ~PlayAudioFileService(){};
+
+      std::string name() const
+      {
+	return name_;
+      }
+
+      std::string topic() const
+      {
+	return topic_;
+      }
+
+      void reset( ros::NodeHandle& nh );
+
+      bool callback( nao_interaction_msgs::AudioPlaybackRequest& req, nao_interaction_msgs::AudioPlaybackResponse& resp );
+
+
+    private:
+      const std::string name_;
+      const std::string topic_;
+
+      const qi::SessionPtr& session_;
+      ros::ServiceServer service_;
+    };
+
+  } // service
+} // naoqi
+#endif


### PR DESCRIPTION
I added service for playing audio file.
related NAOqi API is `void ALAudioPlayerProxy::playFile(const std::string& fileName)` in http://doc.aldebaran.com/2-4/naoqi/audio/alaudioplayer-api.html#alaudioplayer-api

related service is also prepared in [nao_audio.py](https://github.com/ros-naoqi/nao_interaction/blob/master/nao_audio/nodes/nao_audio.py), but I thought I'd like to gather basic services in naoqi_driver.

I tested this with Pepper 2.5.5, ROS kinetic.