### PR TITLE
Feature/stereo

### DIFF
--- a/include/naoqi_driver/naoqi_driver.hpp
+++ b/include/naoqi_driver/naoqi_driver.hpp
@@ -240,6 +240,7 @@ private:
   bool record_enabled_;
   bool log_enabled_;
   bool keep_looping;
+  bool has_stereo;
 
   const size_t freq_;
   boost::thread publisherThread_;

--- a/share/boot_config.json
+++ b/share/boot_config.json
@@ -19,7 +19,15 @@
     "depth_camera":
     {
       "enabled"       : true,
-      "resolution"    : 1,
+      "xtion_resolution": 1,
+      "stereo_resolution": 9,
+      "fps"           : 10,
+      "recorder_fps"  : 5
+    },
+    "stereo_camera":
+    {
+      "enabled"       : true,
+      "resolution"    : 15,
       "fps"           : 10,
       "recorder_fps"  : 5
     },
@@ -93,4 +101,3 @@
     }
   }
 }
-

--- a/src/converters/camera.cpp
+++ b/src/converters/camera.cpp
@@ -152,23 +152,23 @@ const sensor_msgs::CameraInfo& getCameraInfo( int camera_source, int resolution 
       return cam_info_msg;
     }
     else if (resolution == AL::k720px2){
-      static const sensor_msgs::CameraInfo cam_info_msg = createCameraInfoDEPTH720PX2();
+      static const sensor_msgs::CameraInfo cam_info_msg = createCameraInfoStereo720PX2();
       return cam_info_msg;
     }
     else if (resolution == AL::kQ720px2){
-      static const sensor_msgs::CameraInfo cam_info_msg = createCameraInfoDEPTHQ720PX2();
+      static const sensor_msgs::CameraInfo cam_info_msg = createCameraInfoStereoQ720PX2();
       return cam_info_msg;
     }
     else if (resolution == AL::kQQ720px2){
-      static const sensor_msgs::CameraInfo cam_info_msg = createCameraInfoDEPTHQQ720PX2();
+      static const sensor_msgs::CameraInfo cam_info_msg = createCameraInfoStereoQQ720PX2();
       return cam_info_msg;
     }
     else if (resolution == AL::kQQQ720px2){
-      static const sensor_msgs::CameraInfo cam_info_msg = createCameraInfoDEPTHQQQ720PX2();
+      static const sensor_msgs::CameraInfo cam_info_msg = createCameraInfoStereoQQQ720PX2();
       return cam_info_msg;
     }
     else if (resolution == AL::kQQQQ720px2){
-      static const sensor_msgs::CameraInfo cam_info_msg = createCameraInfoDEPTHQQQQ720P();
+      static const sensor_msgs::CameraInfo cam_info_msg = createCameraInfoStereoQQQQ720PX2();
       return cam_info_msg;
     }
   }

--- a/src/converters/camera.hpp
+++ b/src/converters/camera.hpp
@@ -40,7 +40,13 @@ class CameraConverter : public BaseConverter<CameraConverter>
   typedef boost::function<void(sensor_msgs::ImagePtr, sensor_msgs::CameraInfo)> Callback_t;
 
 public:
-  CameraConverter( const std::string& name, const float& frequency, const qi::SessionPtr& session, const int& camera_source, const int& resolution );
+  CameraConverter(
+    const std::string& name,
+    const float& frequency,
+    const qi::SessionPtr& session,
+    const int& camera_source,
+    const int& resolution,
+    const bool& has_stereo=false);
 
   ~CameraConverter();
 

--- a/src/converters/camera_info_definitions.hpp
+++ b/src/converters/camera_info_definitions.hpp
@@ -223,6 +223,113 @@ inline sensor_msgs::CameraInfo createCameraInfoDEPTHQQVGA()
 
   return cam_info_msg;
 }
+
+/**
+* STEREO CAMERA
+*/
+inline sensor_msgs::CameraInfo createCameraInfoStereo(
+        const int &width,
+        const int &height,
+        const float &reductionFactor) {
+
+  sensor_msgs::CameraInfo cam_info_msg;
+
+  cam_info_msg.header.frame_id = "CameraDepth_optical_frame";
+
+  const size_t nK = 9;
+  const size_t nD = 5;
+  const size_t nR = 9;
+  const size_t nP = 12;
+
+  float kTab[nK] = {703.102356f/reductionFactor, 0, 647.821594f/reductionFactor,
+                    0, 702.432312f/reductionFactor, 380.971680f/reductionFactor,
+                    0, 0, 1 };
+
+  float dTab[nD] = {-0.168594331,
+                    .00881872326,
+                    -0.000182721298,
+                    -0.0000145479062,
+                    0.0137237618};
+
+  float rTab[nR] = {0.999984741, 0.000130843779, 0.00552622462,
+                    -0.000111592424, 0.999993920, -0.00348380185,
+                    -0.00552664697, 0.00348313176, 0.999978662};
+
+  float pTab[nP] = {569.869568f/reductionFactor, 0, 644.672058f/reductionFactor, 0,
+                    0, 569.869568f/reductionFactor, 393.368958f/reductionFactor, 0,
+                    0, 0, 1, 0 };
+
+
+  cam_info_msg.width = width;
+  cam_info_msg.height = height;
+
+  for (int i = 0; i < nK; ++i)
+    cam_info_msg.K.at(i) = kTab[i];
+
+  cam_info_msg.distortion_model = "plumb_bob";
+  cam_info_msg.D.assign(dTab, dTab + nD);
+
+  for (int i = 0; i < nR; ++i)
+    cam_info_msg.R.at(i) = rTab[i];
+
+  for (int i = 0; i < nP; ++i)
+    cam_info_msg.P.at(i) = pTab[i];
+
+  return cam_info_msg;
+}
+
+inline sensor_msgs::CameraInfo createCameraInfoDEPTH720P()
+{
+  return createCameraInfoStereo(1280, 720, 1.0);
+}
+
+
+inline sensor_msgs::CameraInfo createCameraInfoDEPTHQ720P()
+{
+  return createCameraInfoStereo(640, 360, 2.0);
+}
+
+inline sensor_msgs::CameraInfo createCameraInfoDEPTHQQ720P()
+{
+  return createCameraInfoStereo(320, 180, 4.0);
+}
+
+inline sensor_msgs::CameraInfo createCameraInfoDEPTHQQQ720P()
+{
+  return createCameraInfoStereo(160, 90, 8.0);
+}
+
+inline sensor_msgs::CameraInfo createCameraInfoDEPTHQQQQ720P()
+{
+  return createCameraInfoStereo(80, 45, 16.0);
+}
+
+// Complete methods for stereo image parameteres
+inline sensor_msgs::CameraInfo createCameraInfoStereo720PX2()
+{
+  return createCameraInfoStereo(2560, 720, 1.0);
+}
+
+inline sensor_msgs::CameraInfo createCameraInfoStereoQ720PX2()
+{
+    return createCameraInfoStereo(1280, 360, 2.0);
+}
+
+inline sensor_msgs::CameraInfo createCameraInfoStereoQQ720PX2()
+{
+    return createCameraInfoStereo(640, 180, 4.0);
+}
+
+inline sensor_msgs::CameraInfo createCameraInfoStereoQQQ720PX2()
+{
+    return createCameraInfoStereo(320, 90, 8.0);
+}
+
+inline sensor_msgs::CameraInfo createCameraInfoStereoQQQQ720PX2()
+{
+    return createCameraInfoStereo(160, 45, 16.0);
+}
+
 } // camera_info_definitions
 } //publisher
 } //naoqi

--- a/src/helpers/driver_helpers.cpp
+++ b/src/helpers/driver_helpers.cpp
@@ -42,19 +42,29 @@ static naoqi_bridge_msgs::RobotInfo& getRobotInfoLocal( const qi::SessionPtr& se
   std::cout << "Receiving information about robot model" << std::endl;
   qi::AnyObject p_memory = session->service("ALMemory");
   std::string robot = p_memory.call<std::string>("getData", "RobotConfig/Body/Type" );
+  std::string version = p_memory.call<std::string>("getData", "RobotConfig/Body/BaseVersion" );
   std::transform(robot.begin(), robot.end(), robot.begin(), ::tolower);
 
   if (std::string(robot) == "nao")
   {
     info.type = naoqi_bridge_msgs::RobotInfo::NAO;
+    std::cout << BOLDYELLOW << "Robot detected: "
+              << BOLDCYAN << "NAO " << version
+              << RESETCOLOR << std::endl;
   }
   if (std::string(robot) == "pepper" || std::string(robot) == "juliette" )
   {
     info.type = naoqi_bridge_msgs::RobotInfo::PEPPER;
+    std::cout << BOLDYELLOW << "Robot detected: "
+              << BOLDCYAN << "Pepper " << version
+              << RESETCOLOR << std::endl;
   }
   if (std::string(robot) == "romeo" )
   {
     info.type = naoqi_bridge_msgs::RobotInfo::ROMEO;
+    std::cout << BOLDYELLOW << "Robot detected: "
+              << BOLDCYAN << "Romeo " << version
+              << RESETCOLOR << std::endl;
   }
 
   // Get the data from RobotConfig

--- a/src/helpers/driver_helpers.cpp
+++ b/src/helpers/driver_helpers.cpp
@@ -223,6 +223,32 @@ std::string& getLanguage( const qi::SessionPtr& session )
   return language;
 }
 
+/**
+ * Function that detects if the robot is using stereo cameras to compute depth
+ */
+bool isDepthStereo(const qi::SessionPtr &session) {
+ std::vector<std::string> sensor_names;
+
+ try {
+   qi::AnyObject p_motion = session->service("ALMotion");
+   sensor_names = p_motion.call<std::vector<std::string>>("getSensorNames");
+
+   if (std::find(sensor_names.begin(),
+                 sensor_names.end(),
+                 "CameraStereo") != sensor_names.end()) {
+     return true;
+   }
+
+   else {
+     return false;
+   }
+
+ } catch (const std::exception &e) {
+   std::cerr << e.what() << std::endl;
+   return false;
+ }
+}
+
 } // driver
 } // helpers
 } // naoqi

--- a/src/helpers/driver_helpers.hpp
+++ b/src/helpers/driver_helpers.hpp
@@ -42,6 +42,8 @@ bool& setLanguage( const qi::SessionPtr& session, naoqi_bridge_msgs::SetStringRe
 
 std::string& getLanguage( const qi::SessionPtr& session );
 
+bool isDepthStereo(const qi::SessionPtr &session);
+
 } // driver
 } // helpers
 } // naoqi

--- a/src/naoqi_driver.cpp
+++ b/src/naoqi_driver.cpp
@@ -124,7 +124,8 @@ Driver::Driver( qi::SessionPtr session, const std::string& prefix )
   log_enabled_(false),
   keep_looping(true),
   recorder_(boost::make_shared<recorder::GlobalRecorder>(prefix)),
-  buffer_duration_(helpers::recorder::bufferDefaultDuration)
+  buffer_duration_(helpers::recorder::bufferDefaultDuration),
+  has_stereo(helpers::driver::isDepthStereo(session))
 {
   if(prefix == ""){
     std::cout << "Error driver prefix must not be empty" << std::endl;
@@ -568,10 +569,17 @@ void Driver::registerDefaultConverter()
   size_t camera_bottom_fps            = boot_config_.get( "converters.bottom_camera.fps", 10);
   size_t camera_bottom_recorder_fps   = boot_config_.get( "converters.bottom_camera.recorder_fps", 5);
 
-  bool camera_depth_enabled           = boot_config_.get( "converters.depth_camera.enabled", true);
-  size_t camera_depth_resolution      = boot_config_.get( "converters.depth_camera.resolution", 1); // QVGA
-  size_t camera_depth_fps             = boot_config_.get( "converters.depth_camera.fps", 10);
-  size_t camera_depth_recorder_fps    = boot_config_.get( "converters.depth_camera.recorder_fps", 5);
+  size_t camera_depth_resolution;
+  bool camera_depth_enabled             = boot_config_.get( "converters.depth_camera.enabled", true);
+  size_t camera_depth_xtion_resolution  = boot_config_.get( "converters.depth_camera.xtion_resolution", 1); // QVGA
+  size_t camera_depth_stereo_resolution = boot_config_.get( "converters.depth_camera.stereo_resolution", 9); // Q720p
+  size_t camera_depth_fps               = boot_config_.get( "converters.depth_camera.fps", 10);
+  size_t camera_depth_recorder_fps      = boot_config_.get( "converters.depth_camera.recorder_fps", 5);
+
+  bool camera_stereo_enabled          = boot_config_.get( "converters.stereo_camera.enabled", true);
+  size_t camera_stereo_resolution     = boot_config_.get( "converters.stereo_camera.resolution", 15); // QQ720px2
+  size_t camera_stereo_fps            = boot_config_.get( "converters.stereo_camera.fps", 10);
+  size_t camera_stereo_recorder_fps    = boot_config_.get( "converters.stereo_camera.recorder_fps", 5);
 
   bool camera_ir_enabled              = boot_config_.get( "converters.ir_camera.enabled", true);
   size_t camera_ir_resolution         = boot_config_.get( "converters.ir_camera.resolution", 1); // QVGA
@@ -593,6 +601,18 @@ void Driver::registerDefaultConverter()
   bool bumper_enabled                 = boot_config_.get( "converters.bumper.enabled", true);
   bool hand_enabled                   = boot_config_.get( "converters.touch_hand.enabled", true);
   bool head_enabled                   = boot_config_.get( "converters.touch_head.enabled", true);
+
+  // Load the correct variables depending on the type of the depth camera
+  // (XTION or stereo). IR disabled if the robot uses a stereo camera to
+  // compute the depth
+  if (this->has_stereo) {
+      camera_ir_enabled = false;
+      camera_depth_resolution = camera_depth_stereo_resolution;
+  }
+  else {
+      camera_depth_resolution = camera_depth_xtion_resolution;
+  }
+
   /*
    * The info converter will be called once after it was added to the priority queue. Once it is its turn to be called, its
    * callAll method will be triggered (because InfoPublisher is considered to always have subscribers, isSubscribed always
@@ -694,19 +714,46 @@ void Driver::registerDefaultConverter()
     {
       boost::shared_ptr<publisher::CameraPublisher> dcp = boost::make_shared<publisher::CameraPublisher>( "camera/depth/image_raw", AL::kDepthCamera );
       boost::shared_ptr<recorder::CameraRecorder> dcr = boost::make_shared<recorder::CameraRecorder>( "camera/depth", camera_depth_recorder_fps );
-      boost::shared_ptr<converter::CameraConverter> dcc = boost::make_shared<converter::CameraConverter>( "depth_camera", camera_depth_fps, sessionPtr_, AL::kDepthCamera, camera_depth_resolution );
+      boost::shared_ptr<converter::CameraConverter> dcc = boost::make_shared<converter::CameraConverter>(
+        "depth_camera",
+        camera_depth_fps,
+        sessionPtr_,
+        AL::kDepthCamera,
+        camera_depth_resolution,
+        this->has_stereo);
+
       dcc->registerCallback( message_actions::PUBLISH, boost::bind(&publisher::CameraPublisher::publish, dcp, _1, _2) );
       dcc->registerCallback( message_actions::RECORD, boost::bind(&recorder::CameraRecorder::write, dcr, _1, _2) );
       dcc->registerCallback( message_actions::LOG, boost::bind(&recorder::CameraRecorder::bufferize, dcr, _1, _2) );
       registerConverter( dcc, dcp, dcr );
     }
 
+    /** Stereo Camera */
+    if (this->has_stereo && camera_stereo_enabled)
+    {
+      boost::shared_ptr<publisher::CameraPublisher> scp = boost::make_shared<publisher::CameraPublisher>( "camera/stereo/image_raw", AL::kInfraredOrStereoCamera );
+      boost::shared_ptr<recorder::CameraRecorder> scr = boost::make_shared<recorder::CameraRecorder>( "camera/stereo", camera_stereo_recorder_fps );
+
+      boost::shared_ptr<converter::CameraConverter> scc = boost::make_shared<converter::CameraConverter>(
+        "stereo_camera",
+        camera_stereo_fps,
+        sessionPtr_,
+        AL::kInfraredOrStereoCamera,
+        camera_stereo_resolution,
+        this->has_stereo);
+
+      scc->registerCallback( message_actions::PUBLISH, boost::bind(&publisher::CameraPublisher::publish, scp, _1, _2) );
+      scc->registerCallback( message_actions::RECORD, boost::bind(&recorder::CameraRecorder::write, scr, _1, _2) );
+      scc->registerCallback( message_actions::LOG, boost::bind(&recorder::CameraRecorder::bufferize, scr, _1, _2) );
+      registerConverter( scc, scp, scr );
+    }
+
     /** Infrared Camera */
     if ( camera_ir_enabled )
     {
-      boost::shared_ptr<publisher::CameraPublisher> icp = boost::make_shared<publisher::CameraPublisher>( "camera/ir/image_raw", AL::kInfraredCamera );
+      boost::shared_ptr<publisher::CameraPublisher> icp = boost::make_shared<publisher::CameraPublisher>( "camera/ir/image_raw", AL::kInfraredOrStereoCamera );
       boost::shared_ptr<recorder::CameraRecorder> icr = boost::make_shared<recorder::CameraRecorder>( "camera/ir", camera_ir_recorder_fps );
-      boost::shared_ptr<converter::CameraConverter> icc = boost::make_shared<converter::CameraConverter>( "infrared_camera", camera_ir_fps, sessionPtr_, AL::kInfraredCamera, camera_ir_resolution);
+      boost::shared_ptr<converter::CameraConverter> icc = boost::make_shared<converter::CameraConverter>( "infrared_camera", camera_ir_fps, sessionPtr_, AL::kInfraredOrStereoCamera, camera_ir_resolution);
       icc->registerCallback( message_actions::PUBLISH, boost::bind(&publisher::CameraPublisher::publish, icp, _1, _2) );
       icc->registerCallback( message_actions::RECORD, boost::bind(&recorder::CameraRecorder::write, icr, _1, _2) );
       icc->registerCallback( message_actions::LOG, boost::bind(&recorder::CameraRecorder::bufferize, icr, _1, _2) );

--- a/src/tools/alvisiondefinitions.h
+++ b/src/tools/alvisiondefinitions.h
@@ -36,7 +36,7 @@ namespace AL
   const int kTopCamera = 0;
   const int kBottomCamera = 1;
   const int kDepthCamera = 2;
-  const int kInfraredCamera = 3;
+  const int kInfraredOrStereoCamera = 3;
 
   const float kApertureH_OV7670  = 47.8f;
   const float kApertureV_OV7670  = 36.8f;
@@ -51,6 +51,15 @@ namespace AL
   const int k16VGA = 4;  //2560*1920
   const int k1920p = k16VGA;  //2560*1920
   const int k720p = 5;  //1280*720
+  const int kQ720p = 9; //640*360
+  const int kQQ720p = 10; //320*180
+  const int kQQQ720p = 11; //160*90
+  const int kQQQQ720p = 12; //80*45
+  const int k720px2 = 13;  //2560*720
+  const int kQ720px2 = 14; //1280*360
+  const int kQQ720px2 = 15; //640*180
+  const int kQQQ720px2 = 16; //320*90
+  const int kQQQQ720px2 = 17; //160*45
   const int k1080p = 6;  //1920*1080
   const int kQQQVGA = 7;  // 80*60
   const int kQQQQVGA = 8;  // 40*30


### PR DESCRIPTION
On Pepper 1.8, the depth information is reconstructed from the stereo information provided by 2 RGB cameras (each RGB camera is located behind each eye, the left eye is used as referential).

This PR makes naoqi_driver compatible with Pepper 1.8 and ensures its compatibility with the previous versions of the robot. On a 1.8 robot, the user will now be able to access to:
* The depth image reconstructed from the stereo
* The raw images coming from the stereo cameras