### PR TITLE
Fix compilation error for indigo

### DIFF
--- a/src/helpers/driver_helpers.cpp
+++ b/src/helpers/driver_helpers.cpp
@@ -241,7 +241,7 @@ bool isDepthStereo(const qi::SessionPtr &session) {
 
  try {
    qi::AnyObject p_motion = session->service("ALMotion");
-   sensor_names = p_motion.call<std::vector<std::string>>("getSensorNames");
+   sensor_names = p_motion.call<std::vector<std::string> >("getSensorNames");
 
    if (std::find(sensor_names.begin(),
                  sensor_names.end(),


### PR DESCRIPTION
Fix compilation error on Indigo brought by PR #111 (Tested for Pepper 1.8 and 1.7 on kinetic). The error has been raised by the Travis CI:
```bash
Building CXX object naoqi_driver/CMakeFiles/naoqi_driver.dir/src/naoqi_driver.cpp.o
/catkin_ws/src/naoqi_driver/src/helpers/driver_helpers.cpp: In function ‘bool naoqi::helpers::driver::isDepthStereo(const SessionPtr&)’:
/catkin_ws/src/naoqi_driver/src/helpers/driver_helpers.cpp:244:56: error: ‘>>’ should be ‘> >’ within a nested template argument list
    sensor_names = p_motion.call<std::vector<std::string>>("getSensorNames");
                                                        ^
make[2]: *** [naoqi_driver/CMakeFiles/naoqi_driver.dir/src/helpers/driver_helpers.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [naoqi_driver/CMakeFiles/naoqi_driver.dir/all] Error 2
```