### PR TITLE
Add velocities and torques to the joint states

### DIFF
--- a/src/converters/joint_state.hpp
+++ b/src/converters/joint_state.hpp
@@ -71,6 +71,7 @@ private:
 
   /** Motion Proxy **/
   qi::AnyObject p_motion_;
+  qi::AnyObject p_memory_;
 
   /** Registered Callbacks **/
   std::map<message_actions::MessageAction, Callback_t> callbacks_;


### PR DESCRIPTION
Adding velocity values and torque values to the joint states. 

For a specific joint, if the velocity (and respectively the torque) value is provided, it is included in the velocity (respectively effort) list of the joint state message. If not, a _nan_ is added to the velocity (respectively effort) list. The velocity information is for instance provided for Pepper's LShoulderPitch, but not for its LHand.