### PR TITLE
Move base with speed

### DIFF
--- a/src/subscribers/moveto.cpp
+++ b/src/subscribers/moveto.cpp
@@ -46,42 +46,122 @@ void MovetoSubscriber::reset( ros::NodeHandle& nh )
   is_initialized_ = true;
 }
 
-void MovetoSubscriber::callback( const geometry_msgs::PoseStampedConstPtr& pose_msg )
+void MovetoSubscriber::callback( const naoqi_bridge_msgs::PoseStampedWithSpeedConstPtr &msg )
 {
-  if ( pose_msg->header.frame_id == "base_footprint" )
-  {
-    double yaw = helpers::transform::getYaw(pose_msg->pose);
 
-    std::cout << "going to move x: " <<  pose_msg->pose.position.x << " y: " << pose_msg->pose.position.y << " z: " << pose_msg->pose.position.z << " yaw: " << yaw << std::endl;
-    p_motion_.async<void>("moveTo", pose_msg->pose.position.x, pose_msg->pose.position.y, yaw);
-  }
-  else{
+  std::vector<std::pair<std::string, float> > moveConfig;
+  float speed;
+
+  // On NAO, the moveTo config will not be applied
+  speed = msg->speed_percentage * 0.45 + 0.1;
+  moveConfig.push_back(std::make_pair("MaxVelXY", speed));
+
+  if (msg->pose_stamped.header.frame_id == "odom") {
     geometry_msgs::PoseStamped pose_msg_bf;
-    //geometry_msgs::TransformStamped tf_trans;
-    //tf_listenerPtr_->waitForTransform( "/base_footprint", pose_msg->header.frame_id, ros::Time(0), ros::Duration(5) );
-    bool canTransform = tf2_buffer_->canTransform("base_footprint", pose_msg->header.frame_id, ros::Time(0), ros::Duration(2) );
+
+    bool canTransform = tf2_buffer_->canTransform(
+      "base_footprint",
+      "odom",
+      ros::Time(0),
+      ros::Duration(2));
+
     if (!canTransform) {
-      std::cout << "Cannot transform from " << pose_msg->header.frame_id << " to base_footprint" << std::endl;
+      std::cout << "Cannot transform from "
+                << "odom"
+                << " to base_footprint"
+                << std::endl;
       return;
     }
-    try
-    {
-      //tf_listenerPtr_->lookupTransform( "/base_footprint", pose_msg->header.frame_id, ros::Time(0), tf_trans);
-      //std::cout << "got a transform " << tf_trans.getOrigin().x() << std::endl;
-      tf2_buffer_->transform( *pose_msg, pose_msg_bf, "base_footprint", ros::Time(0), pose_msg->header.frame_id );
+
+    try {
+      geometry_msgs::PoseStamped pose_stamped = msg->pose_stamped;
+      pose_stamped.header.frame_id = "odom";
+
+      tf2_buffer_->transform(
+        pose_stamped,
+        pose_msg_bf,
+        "base_footprint",
+        ros::Time(0),
+        "odom");
+
       double yaw = helpers::transform::getYaw(pose_msg_bf.pose);
-      std::cout << "odom to move x: " <<  pose_msg_bf.pose.position.x << " y: " << pose_msg_bf.pose.position.y << " z: " << pose_msg_bf.pose.position.z << " yaw: " << yaw << std::endl;
-      p_motion_.async<void>("moveTo", pose_msg_bf.pose.position.x, pose_msg_bf.pose.position.y, yaw );
-    } catch( const tf2::LookupException& e)
-    {
+
+      std::cout << "odom to move x: "
+                <<  pose_msg_bf.pose.position.x
+                << " y: "
+                << pose_msg_bf.pose.position.y
+                << " z: "
+                << pose_msg_bf.pose.position.z
+                << " yaw: "
+                << yaw
+                << std::endl;
+
+      if (std::isnan(yaw)) {
+        yaw = 0.0;
+        std::cout << "Yaw is nan, changed to 0.0" << std::endl;
+      }
+
+      if (robot_ == robot::PEPPER)
+        p_motion_.async<void>(
+          "moveTo",
+          pose_msg_bf.pose.position.x,
+          pose_msg_bf.pose.position.y,
+          yaw,
+          qi::AnyValue::from(moveConfig));
+      else
+        p_motion_.async<void>(
+          "moveTo",
+          pose_msg_bf.pose.position.x,
+          pose_msg_bf.pose.position.y,
+          yaw);
+
+    } catch( const tf2::LookupException& e) {
       std::cout << e.what() << std::endl;
-      std::cout << "moveto position in frame_id " << pose_msg->header.frame_id << "is not supported in any other base frame than basefootprint" << std::endl;
-    }
-    catch( const tf2::ExtrapolationException& e)
-    {
+      std::cout << "moveto position in frame_id "
+                << msg->pose_stamped.header.frame_id
+                << "is not supported in any other base frame than "
+                   "basefootprint"
+                << std::endl;
+    } catch( const tf2::ExtrapolationException& e) {
       std::cout << "received an error on the time lookup" << std::endl;
     }
   }
+
+  else if (msg->pose_stamped.header.frame_id == "base_footprint"){
+    double yaw = helpers::transform::getYaw(msg->pose_stamped.pose);
+    std::cout << "going to move x: "
+              <<  msg->pose_stamped.pose.position.x
+              << " y: " << msg->pose_stamped.pose.position.y
+              << " z: " << msg->pose_stamped.pose.position.z
+              << " yaw: " << yaw << std::endl;
+
+    if (std::isnan(yaw)) {
+      yaw = 0.0;
+      std::cout << "Yaw is nan, changed to 0.0" << std::endl;
+    }
+
+    if (robot_ == robot::PEPPER)
+      p_motion_.async<void>(
+        "moveTo",
+        msg->pose_stamped.pose.position.x,
+        msg->pose_stamped.pose.position.y,
+        yaw,
+        qi::AnyValue::from(moveConfig));
+    else
+      p_motion_.async<void>(
+        "moveTo",
+        msg->pose_stamped.pose.position.x,
+        msg->pose_stamped.pose.position.y,
+        yaw);
+  }
+
+  else
+    std::cout << "Cannot reach position expressed in the "
+              << msg->pose_stamped.header.frame_id
+              << " frame, enter a valid frame id in the pose's header"
+                 " (base_footprint or odom)"
+              << std::endl;
+
 }
 
 } //publisher

--- a/src/subscribers/moveto.hpp
+++ b/src/subscribers/moveto.hpp
@@ -28,8 +28,10 @@
  * ROS includes
  */
 #include <ros/ros.h>
+#include <qi/anyvalue.hpp>
 #include <geometry_msgs/PoseStamped.h>
 #include <tf2_ros/buffer.h>
+#include <naoqi_bridge_msgs/PoseStampedWithSpeed.h>
 
 namespace naoqi
 {
@@ -43,7 +45,7 @@ public:
   ~MovetoSubscriber(){}
 
   void reset( ros::NodeHandle& nh );
-  void callback( const geometry_msgs::PoseStampedConstPtr& pose_msg );
+  void callback( const naoqi_bridge_msgs::PoseStampedWithSpeedConstPtr &msg );
 
 private:
   qi::AnyObject p_motion_;


### PR DESCRIPTION
This PR allows to control the position of Pepper's base while setting a max speed for the movement. 

* The message type expected on __/move_base_simple/goal__ is not a __PoseStamped__ anymore but a __PoseStampedWithSpeed__ (defined in __naoqi_bridge_msgs__, in that [PR](https://github.com/ros-naoqi/naoqi_bridge_msgs/pull/43))
* The specified speed will only be taken into account if the robot is a Pepper
* The __PoseStamped__ can only be referenced in "base_footprint" or in "odom", no movement will be launched if another frame is specified
* If the quaternion of the __PoseStamed__ is invalid, the corresponding yaw will be set to 0.0 (nan before, could make the robot fall)