### PR TITLE
pass rosdep eol flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ install:
 script:
   - sudo docker run -t -d --name=$DOCKER_VERSION -v $CI_SOURCE_PATH/../:/catkin_ws/src/ osrf/ros:$DOCKER_VERSION bash
   - sudo docker exec -i $DOCKER_VERSION apt-get update
+  - sudo docker exec -i $DOCKER_VERSION rosdep update --include-eol-distros
   - sudo docker exec -i $DOCKER_VERSION rosdep install -i -y --from-paths /catkin_ws/src/naoqi_driver
   - sudo docker exec -i $DOCKER_VERSION bash -c 'source /opt/ros/*/setup.bash; catkin_make --directory catkin_ws/'
   - sudo docker exec -i $DOCKER_VERSION bash -c 'source /opt/ros/*/setup.bash; catkin_make run_tests --directory /catkin_ws/'


### PR DESCRIPTION
rosdep database is not up to date as these images have been EOL for a while.
Running rosdep update with the `--include-eol-distros` flag should hopefully fix the rosdep install error.

Travis should most likely fail the job when a command fail rather than trying to build anyway

Signed-off-by: Mikael Arguedas <mikael.arguedas@gmail.com>