### PR TITLE
upgrade to make sure all package versions are consistent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ install:
 script:
   - sudo docker run -t -d --name=$DOCKER_VERSION -v $CI_SOURCE_PATH/../:/catkin_ws/src/ osrf/ros:$DOCKER_VERSION bash
   - sudo docker exec -i $DOCKER_VERSION apt-get update
+  - sudo docker exec -i $DOCKER_VERSION apt-get upgrade -y
   - sudo docker exec -i $DOCKER_VERSION rosdep update --include-eol-distros
   - sudo docker exec -i $DOCKER_VERSION rosdep install -i -y --from-paths /catkin_ws/src/naoqi_driver
   - sudo docker exec -i $DOCKER_VERSION bash -c 'source /opt/ros/*/setup.bash; catkin_make --directory catkin_ws/'


### PR DESCRIPTION
Fix orocos failure on kinetic.

An alternative fix would be to call `rosdep install` with the reinstall flag but I'm not sure it'd be faster and having an overall up-to-date environment for testing would be better.

The original issue doesn't come from this repo though but from the fact that the docker images are not up-to-date: https://github.com/osrf/docker_images/issues/112

Signed-off-by: Mikael Arguedas <mikael.arguedas@gmail.com>