### PR TITLE
Use std::numeric_limits<double>::quiet_NaN for indigo compatibility

### DIFF
--- a/src/converters/joint_state.cpp
+++ b/src/converters/joint_state.cpp
@@ -128,8 +128,8 @@ void JointStateConverter::callAll( const std::vector<message_actions::MessageAct
 
     } catch (qi::FutureUserException e) {
         // Sets the velocity and torques field to nan if no info is provided
-        al_joint_velocities.push_back(std::nan(".NAN"));
-        al_joint_torques.push_back(std::nan(".NAN"));
+        al_joint_velocities.push_back(std::numeric_limits<double>::quiet_NaN());
+        al_joint_torques.push_back(std::numeric_limits<double>::quiet_NaN());
     }
   }
 


### PR DESCRIPTION
Replacing std::nan by std::numeric_limits<double>::quiet_NaN in [joint_state.cpp](https://github.com/ros-naoqi/naoqi_driver/blob/198a49831d34b7a95ac273c56ae171ea8cc5e41d/src/converters/joint_state.cpp#L131), for the compatibility with indigo.