### PR TITLE
Parametrizable range for Pepper's lasers

### DIFF
--- a/share/boot_config.json
+++ b/share/boot_config.json
@@ -71,7 +71,9 @@
     "laser":
     {
       "enabled"       : true,
-      "frequency"     : 10
+      "frequency"     : 10,
+      "range_min"     : 0.1,
+      "range_max"     : 3.0
     },
     "sonar":
     {

--- a/src/converters/laser.cpp
+++ b/src/converters/laser.cpp
@@ -216,9 +216,24 @@ void LaserConverter::reset( )
   msg_.angle_min = -2.0944;   // -120
   msg_.angle_max = 2.0944;    // +120
   msg_.angle_increment = (2*2.0944) / (15+15+15+8+8); // 240 deg FoV / 61 points (blind zones inc)
-  msg_.range_min = 0.1; // in m
-  msg_.range_max = 1.5; // in m
+  msg_.range_min = this->range_min_; // in m
+  msg_.range_max = this->range_max_; // in m
   msg_.ranges = std::vector<float>(61, -1.0f);
+}
+
+void LaserConverter::setLaserRanges(
+    const float &range_min,
+    const float &range_max) {
+  
+  if (range_min > 0)
+    this->range_min_ = range_min;
+  else
+    this->range_min_ = 0.1;
+  
+  if (range_max > this->range_min_)
+    this->range_max_ = range_max;
+  else
+    this->range_max_ = 3.0;
 }
 
 } //converter

--- a/src/converters/laser.hpp
+++ b/src/converters/laser.hpp
@@ -48,9 +48,13 @@ public:
 
   void reset( );
 
+  void setLaserRanges(const float &range_min, const float &range_max);
+
 private:
 
   qi::AnyObject p_memory_;
+  float range_min_;
+  float range_max_;
 
   std::map<message_actions::MessageAction, Callback_t> callbacks_;
   sensor_msgs::LaserScan msg_;

--- a/src/naoqi_driver.cpp
+++ b/src/naoqi_driver.cpp
@@ -591,6 +591,8 @@ void Driver::registerDefaultConverter()
 
   bool laser_enabled                  = boot_config_.get( "converters.laser.enabled", true);
   size_t laser_frequency              = boot_config_.get( "converters.laser.frequency", 10);
+  float laser_range_min              = boot_config_.get<float>("converters.laser.range_min", 0.1);
+  float laser_range_max              = boot_config_.get<float>("converters.laser.range_max", 3.0);
 
   bool sonar_enabled                  = boot_config_.get( "converters.sonar.enabled", true);
   size_t sonar_frequency              = boot_config_.get( "converters.sonar.frequency", 10);
@@ -782,6 +784,8 @@ void Driver::registerDefaultConverter()
       boost::shared_ptr<publisher::BasicPublisher<sensor_msgs::LaserScan> > lp = boost::make_shared<publisher::BasicPublisher<sensor_msgs::LaserScan> >( "laser" );
       boost::shared_ptr<recorder::BasicRecorder<sensor_msgs::LaserScan> > lr = boost::make_shared<recorder::BasicRecorder<sensor_msgs::LaserScan> >( "laser" );
       boost::shared_ptr<converter::LaserConverter> lc = boost::make_shared<converter::LaserConverter>( "laser", laser_frequency, sessionPtr_ );
+
+      lc->setLaserRanges(laser_range_min, laser_range_max);
       lc->registerCallback( message_actions::PUBLISH, boost::bind(&publisher::BasicPublisher<sensor_msgs::LaserScan>::publish, lp, _1) );
       lc->registerCallback( message_actions::RECORD, boost::bind(&recorder::BasicRecorder<sensor_msgs::LaserScan>::write, lr, _1) );
       lc->registerCallback( message_actions::LOG, boost::bind(&recorder::BasicRecorder<sensor_msgs::LaserScan>::bufferize, lr, _1) );


### PR DESCRIPTION
The range of Pepper's lasers can be configured using the boot-config.json file. By default, the laser range has been updated to [0.1, 3.0] meters.

This answers the issue #80, and has been tested on Pepper 1.8a / NAOqi 2.5.5.5