### PR TITLE
remove EOL ROS Lunar from travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,6 @@ matrix:
   include:
     - env: DOCKER_VERSION=indigo-desktop-trusty
     - env: DOCKER_VERSION=kinetic-desktop-xenial
-    - env: DOCKER_VERSION=lunar-desktop-xenial
-    - env: DOCKER_VERSION=lunar-desktop-stretch
 
 env:
   global:

--- a/README.rst
+++ b/README.rst
@@ -46,19 +46,9 @@ Travis - Continuous Integration
     :alt: Kinetic with Ubuntu Xenial
     :target: https://travis-ci.org/ros-naoqi/naoqi_driver/
 
-.. |lunar| image:: https://travis-matrix-badges.herokuapp.com/repos/ros-naoqi/naoqi_driver/branches/master/3
-    :alt: Lunar with Ubuntu Xenial
-    :target: https://travis-ci.org/ros-naoqi/naoqi_driver/
-
-.. |lunar_stretch| image:: https://travis-matrix-badges.herokuapp.com/repos/ros-naoqi/naoqi_driver/branches/master/4
-    :alt: Lunar with Debian Stretch
-    :target: https://travis-ci.org/ros-naoqi/naoqi_driver/
-
 +-------------+---------------+---------------+-----------------+
 | ROS Release | Ubuntu Trusty | Ubuntu Xenial | Debian Stretch  |
 +=============+===============+===============+=================+
-| Lunar       | N/A           | |lunar|       | |lunar_stretch| |
-+-------------+---------------+---------------+-----------------+
 | Kinetic     | N/A           | |kinetic|     | N/A             |
 +-------------+---------------+---------------+-----------------+
 | Indigo      | |indigo|      | N/A           | N/A             |


### PR DESCRIPTION
Signed-off-by: Mikael Arguedas <mikael.arguedas@gmail.com>

ROS Lunar is EOL and this package never built successfully against it. Removing it to bring green CI and in prevision of Melodic / Noetic support