### PR TITLE
use industrial_ci instead of custom CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,47 +1,36 @@
-branches:
-    only:
-      - master
-
-notifications:
-    on_success: never
-    on_failure: never
-
-os :
-  - linux
-
-dist:
-  - trusty
-
-sudo:
-  - required
-
-
-language:
-  - generic
+# This config uses industrial_ci (https://github.com/ros-industrial/industrial_ci.git).
+# For troubleshooting, see readme (https://github.com/ros-industrial/industrial_ci/blob/master/README.rst)
 
 services:
   - docker
 
-matrix:
-  include:
-    - env: DOCKER_VERSION=indigo-desktop-trusty
-    - env: DOCKER_VERSION=kinetic-desktop-xenial
+# include the following block if the C/C++ build artifacts should get cached by Travis,
+# CCACHE_DIR needs to get set as well to actually fill the cache
+cache:
+  directories:
+    - $HOME/.ccache
 
+git:
+  quiet: true # optional, silences the cloning of the target repository
+
+# configure the build environment(s)
+# https://github.com/ros-industrial/industrial_ci/blob/master/doc/index.rst#variables-you-can-configure
 env:
-  global:
-    - CI_SOURCE_PATH=$(pwd)
+  global: # global settings for all jobs
+    - ROS_REPO=ros
+    - CCACHE_DIR=$HOME/.ccache # enables C/C++ caching in industrial_ci
+  matrix: # each line is a job
+    - ROS_DISTRO="indigo"
+    - ROS_DISTRO="kinetic"
+    - ROS_DISTRO="melodic"
 
+# allow failures, e.g. for unsupported distros
+matrix:
+  allow_failures:
+    - env: ROS_DISTRO="melodic"
+
+# clone and run industrial_ci
 install:
-  - sudo docker pull osrf/ros:$DOCKER_VERSION
-
+  - git clone --quiet --depth 1 https://github.com/ros-industrial/industrial_ci.git .industrial_ci -b master
 script:
-  - sudo docker run -t -d --name=$DOCKER_VERSION -v $CI_SOURCE_PATH/../:/catkin_ws/src/ osrf/ros:$DOCKER_VERSION bash
-  - sudo docker exec -i $DOCKER_VERSION apt-get update
-  - sudo docker exec -i $DOCKER_VERSION apt-get upgrade -y
-  - sudo docker exec -i $DOCKER_VERSION rosdep update --include-eol-distros
-  - sudo docker exec -i $DOCKER_VERSION rosdep install -i -y --from-paths /catkin_ws/src/naoqi_driver
-  - sudo docker exec -i $DOCKER_VERSION bash -c 'source /opt/ros/*/setup.bash; catkin_make --directory catkin_ws/'
-  - sudo docker exec -i $DOCKER_VERSION bash -c 'source /opt/ros/*/setup.bash; catkin_make run_tests --directory /catkin_ws/'
-
-after_script:
-  - sudo docker stop $DOCKER_VERSION
+  - .industrial_ci/travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 # This config uses industrial_ci (https://github.com/ros-industrial/industrial_ci.git).
 # For troubleshooting, see readme (https://github.com/ros-industrial/industrial_ci/blob/master/README.rst)
 
+notifications:
+  email:
+    if: branch = master
+    on_success: change
+    on_failure: always
 services:
   - docker
 


### PR DESCRIPTION
Signed-off-by: Mikael Arguedas <mikael.arguedas@gmail.com>

WIP: experiment with industrial_ci to avoid custom logic in travis.yml

Pros:
- start from scratch image so not rely on packages in desktop but actually checking that dependencies are declared properly
- no custom logic, rely on vastly adopted tool instead
- this runs the installation phase as well
- allow finer grain control, e.g. here enabling melodic builds but allowing it to fail until it's ready for prime time

Cons:
- takes a bit longer
- runs on all branches (thats actually a pro for me but it's debatable)
- send email notifications on success (need to be configured)