### PR TITLE
Adapt the README to the new CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,12 +27,14 @@ env:
   matrix: # each line is a job
     - ROS_DISTRO="indigo"
     - ROS_DISTRO="kinetic"
-    - ROS_DISTRO="melodic"
+    - ROS_DISTRO="melodic" OS_NAME=ubuntu OS_CODE_NAME=bionic
+    - ROS_DISTRO="melodic" OS_NAME=debian OS_CODE_NAME=stretch
 
 # allow failures, e.g. for unsupported distros
 matrix:
   allow_failures:
-    - env: ROS_DISTRO="melodic"
+    - env: ROS_DISTRO="melodic" OS_NAME=ubuntu OS_CODE_NAME=bionic
+    - env: ROS_DISTRO="melodic" OS_NAME=debian OS_CODE_NAME=stretch
 
 # clone and run industrial_ci
 install:

--- a/README.rst
+++ b/README.rst
@@ -50,12 +50,18 @@ Travis - Continuous Integration
     :alt: Melodic with Ubuntu Bionic
     :target: https://travis-ci.org/ros-naoqi/naoqi_driver/
 
-+-------------+---------------+---------------+-----------------+
-| ROS Release | Ubuntu Trusty | Ubuntu Xenial | Ubuntu Bionic   |
-+=============+===============+===============+=================+
-| Melodic     | N/A           | N/A           | |melodic|       |
-+-------------+---------------+---------------+-----------------+
-| Kinetic     | N/A           | |kinetic|     | N/A             |
-+-------------+---------------+---------------+-----------------+
-| Indigo      | |indigo|      | N/A           | N/A             |
-+-------------+---------------+---------------+-----------------+
+.. |melodic-stretch| image:: https://travis-matrix-badges.herokuapp.com/repos/ros-naoqi/naoqi_driver/branches/master/4
+    :alt: Melodic with Debian Stretch
+    :target: https://travis-ci.org/ros-naoqi/naoqi_driver/
+
++-----------------+---------------------+
+|   ROS Release   |       status        |
++=================+=====================+
+| Melodic-stretch |  |melodic-stretch|  |
++-----------------+---------------------+
+| Melodic         |     |melodic|       |
++-----------------+---------------------+
+| Kinetic         |     |kinetic|       |
++-----------------+---------------------+
+| Indigo          |     |indigo|        |
++-----------------+---------------------+

--- a/README.rst
+++ b/README.rst
@@ -46,9 +46,15 @@ Travis - Continuous Integration
     :alt: Kinetic with Ubuntu Xenial
     :target: https://travis-ci.org/ros-naoqi/naoqi_driver/
 
+.. |melodic| image:: https://travis-matrix-badges.herokuapp.com/repos/ros-naoqi/naoqi_driver/branches/master/3
+    :alt: Melodic with Ubuntu Bionic
+    :target: https://travis-ci.org/ros-naoqi/naoqi_driver/
+
 +-------------+---------------+---------------+-----------------+
-| ROS Release | Ubuntu Trusty | Ubuntu Xenial | Debian Stretch  |
+| ROS Release | Ubuntu Trusty | Ubuntu Xenial | Ubuntu Bionic   |
 +=============+===============+===============+=================+
+| Melodic     | N/A           | N/A           | |melodic|       |
++-------------+---------------+---------------+-----------------+
 | Kinetic     | N/A           | |kinetic|     | N/A             |
 +-------------+---------------+---------------+-----------------+
 | Indigo      | |indigo|      | N/A           | N/A             |


### PR DESCRIPTION
Modify the CI section of the README to match the new CI. Currently only Ubuntu distros are targeted for the tests (guessed from [ROS_DISTRO](https://github.com/ros-naoqi/naoqi_driver/blob/208c96eec3e5b10df327a642324f66f5f83f8943/.travis.yml#L28)), the CI could be extended with Debian distros, etc. (see [here](https://github.com/ros-industrial/industrial_ci/blob/legacy/doc/index.rst#ubuntu-and-its-distro-are-guessed-by-default-from-ros-distro) and [here](https://github.com/ros-industrial/docker/tree/master/ci)) 