### PR TITLE
Update CI for melodic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,7 @@ env:
 # allow failures, e.g. for unsupported distros
 matrix:
   allow_failures:
-    - env: ROS_DISTRO="melodic" OS_NAME=ubuntu OS_CODE_NAME=bionic
-    - env: ROS_DISTRO="melodic" OS_NAME=debian OS_CODE_NAME=stretch
+    - env: ROS_DISTRO="indigo"
 
 # clone and run industrial_ci
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ git:
 # https://github.com/ros-industrial/industrial_ci/blob/master/doc/index.rst#variables-you-can-configure
 env:
   global: # global settings for all jobs
-    - ROS_REPO=ros
+    - ROS_REPO=testing
     - CCACHE_DIR=$HOME/.ccache # enables C/C++ caching in industrial_ci
   matrix: # each line is a job
     - ROS_DISTRO="indigo"


### PR DESCRIPTION
Move CI to using the testing repository (as this represent packages that will be part of the next ROS sync it is better to test incoming PRs. Here it'll allow to depend on packages like `naoqi_libqicore` that haven't made it to the main repo yet)
Melodic job are not allowed to fail anymore
