### PR TITLE
workarounds for simulated robots

### DIFF
--- a/src/helpers/driver_helpers.cpp
+++ b/src/helpers/driver_helpers.cpp
@@ -41,8 +41,20 @@ static naoqi_bridge_msgs::RobotInfo& getRobotInfoLocal( const qi::SessionPtr& se
   // Get the robot type
   std::cout << "Receiving information about robot model" << std::endl;
   qi::AnyObject p_memory = session->service("ALMemory");
-  std::string robot = p_memory.call<std::string>("getData", "RobotConfig/Body/Type" );
-  std::string version = p_memory.call<std::string>("getData", "RobotConfig/Body/BaseVersion" );
+  std::string robot; 
+  try {
+    robot = p_memory.call<std::string>("getData", "RobotConfig/Body/Type" );
+  }
+  catch(const qi::FutureUserException& e) {
+    robot = p_memory.call<std::string>("getData", "Dialog/RobotModel" );
+  }
+  std::string version;
+  try {
+    version = p_memory.call<std::string>("getData", "RobotConfig/Body/BaseVersion" );
+  }
+  catch(const qi::FutureUserException& e) {
+    version = "unknown";
+  }
   std::transform(robot.begin(), robot.end(), robot.begin(), ::tolower);
 
   if (std::string(robot) == "nao")
@@ -257,6 +269,17 @@ bool isDepthStereo(const qi::SessionPtr &session) {
    std::cerr << e.what() << std::endl;
    return false;
  }
+}
+
+bool isRealRobot(const qi::SessionPtr &session) {
+  qi::AnyObject p_memory = session->service("ALMemory");
+  try {
+    p_memory.call<std::string>("getData", "RobotConfig/Body/Type" );
+    return true;
+  }
+  catch(const qi::FutureUserException& e) {
+    return false;
+  }
 }
 
 } // driver

--- a/src/helpers/driver_helpers.hpp
+++ b/src/helpers/driver_helpers.hpp
@@ -44,6 +44,8 @@ std::string& getLanguage( const qi::SessionPtr& session );
 
 bool isDepthStereo(const qi::SessionPtr &session);
 
+bool isRealRobot(const qi::SessionPtr &session);
+
 } // driver
 } // helpers
 } // naoqi

--- a/src/naoqi_driver.cpp
+++ b/src/naoqi_driver.cpp
@@ -165,6 +165,9 @@ void Driver::loadBootConfig()
   if (!file_path.empty())
   {
     boost::property_tree::read_json( file_path, boot_config_ );
+    if(!helpers::driver::isRealRobot(sessionPtr_)) {
+      boot_config_.put("converters.audio.enabled", false);
+    }
   }
 }
 


### PR DESCRIPTION
Currently, trying to connect to a simulated robot, either using Choregaphe or by running `naoqi-bin` manually, will lead to errors stopping the node to start.

There are two problems, at least for Nao:
 1. The robot type has to be accessed using `Dialog/RobotModel` instead of `RobotConfig/Body/Type`
 2. The simulated robot doesn't provide the `ALAudio` module

This PR addresses both of these problems. 

One small issue is that I couldn't find a way to retrieve the robot's version. That shouldn't be a big issue since this information is only used for message logging.