### PR TITLE
Naoqi 2.9 compatibility

### DIFF
--- a/include/naoqi_driver/tools.hpp
+++ b/include/naoqi_driver/tools.hpp
@@ -41,6 +41,15 @@ enum Robot
   PEPPER,
   ROMEO
 };
+
+struct NaoqiVersion
+{
+  int major;
+  int minor;
+  int patch;
+  int build;
+  std::string text;
+};
 }
 
 enum Topics {

--- a/launch/naoqi_driver.launch
+++ b/launch/naoqi_driver.launch
@@ -5,7 +5,9 @@
   <arg name="roscore_ip"        default="127.0.0.1" />
   <arg name="network_interface" default="eth0" />
   <arg name="namespace"         default="naoqi_driver" />
+  <arg name="user"              default="nao" />
+  <arg name="password"          default="no_password" />
 
-  <node pkg="naoqi_driver" type="naoqi_driver_node" name="$(arg namespace)" required="true" args="--qi-url=tcp://$(arg nao_ip):$(arg nao_port) --roscore_ip=$(arg roscore_ip) --network_interface=$(arg network_interface) --namespace=$(arg namespace)" output="screen" />
+  <node pkg="naoqi_driver" type="naoqi_driver_node" name="$(arg namespace)" required="true" args="--qi-url=tcp://$(arg nao_ip):$(arg nao_port) --nao_ip=$(arg nao_ip) --nao_port=$(arg nao_port) --user=$(arg user) --password=$(arg password) --roscore_ip=$(arg roscore_ip) --network_interface=$(arg network_interface) --namespace=$(arg namespace)" output="screen" />
 
 </launch>

--- a/src/converters/converter_base.hpp
+++ b/src/converters/converter_base.hpp
@@ -45,6 +45,7 @@ public:
     name_( name ),
     frequency_( frequency ),
     robot_( helpers::driver::getRobot(session) ),
+    naoqi_version_( helpers::driver::getNaoqiVersion(session) ),
     session_(session),
     record_enabled_(false)
   {}
@@ -68,6 +69,8 @@ protected:
   float frequency_;
   /** The type of the robot */
   const robot::Robot& robot_;
+  /* The version of the Naoqi Software on the robot */
+  const robot::NaoqiVersion& naoqi_version_;
 
   /** Pointer to a session from which we can create proxies */
   qi::SessionPtr session_;

--- a/src/converters/diagnostics.cpp
+++ b/src/converters/diagnostics.cpp
@@ -60,7 +60,12 @@ DiagnosticsConverter::DiagnosticsConverter( const std::string& name, float frequ
   // Allow for temperature reporting (for CPU)
   if ((robot_ == robot::PEPPER) || (robot_ == robot::NAO)) {
     p_body_temperature_ = session->service("ALBodyTemperature");
-    p_body_temperature_.call<void>("setEnableNotifications", true);
+
+    // Only call setEnableNotifications if NAOqi < 2.9
+    if (helpers::driver::isNaoqiVersionLesser(naoqi_version_, 2, 9))
+    {
+      p_body_temperature_.call<void>("setEnableNotifications", true);
+    }
   }
 
   std::vector<std::vector<float> > joint_limits;

--- a/src/converters/sonar.cpp
+++ b/src/converters/sonar.cpp
@@ -35,9 +35,14 @@ namespace converter
 SonarConverter::SonarConverter( const std::string& name, const float& frequency, const qi::SessionPtr& session )
   : BaseConverter( name, frequency, session ),
     p_memory_( session->service("ALMemory") ),
-    p_sonar_( session->service("ALSonar") ),
     is_subscribed_(false)
 {
+  // Only create a sonar proxy if NAOqi < 2.9
+  if (helpers::driver::isNaoqiVersionLesser(naoqi_version_, 2, 9))
+  {
+    p_sonar_ = session->service("ALSonar");
+  }
+
   std::vector<std::string> keys;
   if (robot_ == robot::PEPPER) {
     keys.push_back("Device/SubDeviceList/Platform/Front/Sonar/Sensor/Value");
@@ -74,7 +79,7 @@ SonarConverter::SonarConverter( const std::string& name, const float& frequency,
 
 SonarConverter::~SonarConverter()
 {
-  if (is_subscribed_)
+  if (is_subscribed_ && helpers::driver::isNaoqiVersionLesser(naoqi_version_, 2, 9))
   {
     p_sonar_.call<void>("unsubscribe", "ROS");
     is_subscribed_ = false;
@@ -88,7 +93,7 @@ void SonarConverter::registerCallback( message_actions::MessageAction action, Ca
 
 void SonarConverter::callAll( const std::vector<message_actions::MessageAction>& actions )
 {
-  if (!is_subscribed_)
+  if (!is_subscribed_ && helpers::driver::isNaoqiVersionLesser(naoqi_version_, 2, 9))
   {
     p_sonar_.call<void>("subscribe", "ROS");
     is_subscribed_ = true;
@@ -117,7 +122,7 @@ void SonarConverter::callAll( const std::vector<message_actions::MessageAction>&
 
 void SonarConverter::reset( )
 {
-  if (is_subscribed_)
+  if (is_subscribed_ && helpers::driver::isNaoqiVersionLesser(naoqi_version_, 2, 9))
   {
     p_sonar_.call<void>("unsubscribe", "ROS");
     is_subscribed_ = false;

--- a/src/driver_authenticator.hpp
+++ b/src/driver_authenticator.hpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2015 Aldebaran
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef DRIVER_AUTHENTICATOR_HPP
+#define DRIVER_AUTHENTICATOR_HPP
+
+#include <qi/messaging/authprovider.hpp>
+
+namespace naoqi {
+
+class DriverAuthenticator : public qi::ClientAuthenticator {
+public:
+  static const std::string user_key;
+  static const std::string pass_key;
+
+  DriverAuthenticator(
+    const std::string& user, 
+    const std::string& pass) : _u(user), _p(pass) {}
+
+  qi::CapabilityMap initialAuthData() {
+    qi::CapabilityMap result;
+    result[DriverAuthenticator::user_key] = qi::AnyValue::from(_u);
+    result[DriverAuthenticator::pass_key] = qi::AnyValue::from(_p);
+    return result;
+  }
+
+  qi::CapabilityMap _processAuth(const qi::CapabilityMap&) {
+    return qi::CapabilityMap();
+  }
+private:
+  std::string _u;
+  std::string _p;
+};
+
+const std::string DriverAuthenticator::user_key = "user";
+const std::string DriverAuthenticator::pass_key = "token";
+
+class DriverAuthenticatorFactory : public qi::ClientAuthenticatorFactory {
+public:
+  std::string user;
+  std::string pass;
+
+  qi::ClientAuthenticatorPtr newAuthenticator() {
+    return boost::make_shared<DriverAuthenticator>(user, pass);
+  }
+};
+
+}
+
+#endif // DRIVER_AUTHENTICATOR

--- a/src/event/audio.cpp
+++ b/src/event/audio.cpp
@@ -32,21 +32,33 @@
 namespace naoqi
 {
 
-AudioEventRegister::AudioEventRegister()
-{
-}
-
 AudioEventRegister::AudioEventRegister( const std::string& name, const float& frequency, const qi::SessionPtr& session )
   : serviceId(0),
     p_audio_( session->service("ALAudioDevice")),
     p_robot_model_(session->service("ALRobotModel")),
     session_(session),
+    naoqi_version_(helpers::driver::getNaoqiVersion(session)),
     isStarted_(false),
     isPublishing_(false),
     isRecording_(false),
     isDumping_(false)
 {
-  int micConfig = p_robot_model_.call<int>("_getMicrophoneConfig");
+  // _getMicrophoneConfig is used for NAOqi < 2.9, _getConfigMap for NAOqi > 2.9
+  int micConfig;
+
+  if (helpers::driver::isNaoqiVersionLesser(naoqi_version_, 2, 9))
+  {
+    micConfig = p_robot_model_.call<int>("_getMicrophoneConfig");
+  }
+  else
+  {
+    std::map<std::string, std::string> config_map =\
+      p_robot_model_.call<std::map<std::string, std::string> >("_getConfigMap");
+
+    micConfig = std::atoi(
+      config_map["RobotConfig/Head/Device/Micro/Version"].c_str());
+  }
+
   if(micConfig){
     channelMap.push_back(3);
     channelMap.push_back(5);

--- a/src/event/audio.hpp
+++ b/src/event/audio.hpp
@@ -58,7 +58,6 @@ public:
   /**
   * @brief Constructor for recorder interface
   */
-  AudioEventRegister();
   AudioEventRegister( const std::string& name, const float& frequency, const qi::SessionPtr& session );
   ~AudioEventRegister();
 
@@ -93,6 +92,7 @@ private:
   qi::FutureSync<qi::AnyObject> p_audio_extractor_request;
   std::vector<uint8_t> channelMap;
   unsigned int serviceId;
+  const robot::NaoqiVersion& naoqi_version_;
 
   boost::mutex subscription_mutex_;
   boost::mutex processing_mutex_;

--- a/src/external_registration.cpp
+++ b/src/external_registration.cpp
@@ -25,8 +25,16 @@
 #include "naoqi_env.hpp"
 #include "helpers/driver_helpers.hpp"
 
+#if LIBQI_VERSION >= 29
+#include "driver_authenticator.hpp"
+#endif
+
+
 int main(int argc, char** argv)
 {
+  const std::string no_password = "no_password";
+  std::string protocol = "tcp://";
+
   /* launch naoqi service */
   qi::ApplicationSession app(argc, argv);
   /* In case you launch via roslaunch/rosrun we remove the ros args */
@@ -37,6 +45,10 @@ int main(int argc, char** argv)
   po::options_description desc("Options");
   desc.add_options()
     ("help,h", "print help message")
+    ("nao_ip", po::value<std::string>(), "the ip of the robot")
+    ("nao_port", po::value<int>(), "the ip of the robot")
+    ("user,u", po::value<std::string>(), "the user profile on the robot, nao by default")
+    ("password,p", po::value<std::string>(), "the password of the robot")
     ("roscore_ip,r", po::value<std::string>(), "set the ip of the roscore to use")
     ("network_interface,i", po::value<std::string>()->default_value("eth0"),  "set the network interface over which to connect")
     ("namespace,n", po::value<std::string>()->default_value("naoqi_driver_node"), "set an explicit namespace in case ROS namespace variables cannot be used");
@@ -63,15 +75,30 @@ int main(int argc, char** argv)
     exit(0);
   }
 
-
-  // everything's correctly parsed - let's start the app!
-#if LIBQI_VERSION>24
-  app.startSession();
+  if (vm["password"].as<std::string>().compare(no_password) != 0) {
+#if LIBQI_VERSION>=29
+    protocol = "tcps://";
+    naoqi::DriverAuthenticatorFactory *factory = new naoqi::DriverAuthenticatorFactory;
+    factory->user = vm["user"].as<std::string>();
+    factory->pass = vm["password"].as<std::string>();
+    app.session()->setClientAuthenticatorFactory(qi::ClientAuthenticatorFactoryPtr(factory));
 #else
-  app.start();
+    std::cout << BOLDRED 
+              << "No need to set a password" 
+              << RESETCOLOR
+              << std::endl;
 #endif
-  boost::shared_ptr<naoqi::Driver> bs = boost::make_shared<naoqi::Driver>(app.session(), vm["namespace"].as<std::string>());
+  }
 
+  qi::Url url(protocol + vm["nao_ip"].as<std::string>() + ":" + std::to_string(vm["nao_port"].as<int>()));
+  qi::Future<void> connection = app.session()->connect(url);
+
+  if (connection.hasError()) {
+    std::cout << BOLDRED << connection.error() <<  RESETCOLOR << std::endl;
+    return 0;
+  }
+
+  boost::shared_ptr<naoqi::Driver> bs = boost::make_shared<naoqi::Driver>(app.session(), vm["namespace"].as<std::string>());
   app.session()->registerService("ROS-Driver", bs);
 
   // set ros paramters directly upfront if available

--- a/src/helpers/driver_helpers.cpp
+++ b/src/helpers/driver_helpers.cpp
@@ -42,30 +42,29 @@ static naoqi_bridge_msgs::RobotInfo& getRobotInfoLocal( const qi::SessionPtr& se
   std::cout << "Receiving information about robot model" << std::endl;
   qi::AnyObject p_memory = session->service("ALMemory");
   std::string robot = p_memory.call<std::string>("getData", "RobotConfig/Body/Type" );
-  std::string version = p_memory.call<std::string>("getData", "RobotConfig/Body/BaseVersion" );
+  std::string hardware_version = p_memory.call<std::string>("getData", "RobotConfig/Body/BaseVersion" );
+  robot::NaoqiVersion naoqi_version = getNaoqiVersion(session);
   std::transform(robot.begin(), robot.end(), robot.begin(), ::tolower);
+
+  std::cout << BOLDYELLOW << "Robot detected/NAOqi version: " << RESETCOLOR;
 
   if (std::string(robot) == "nao")
   {
     info.type = naoqi_bridge_msgs::RobotInfo::NAO;
-    std::cout << BOLDYELLOW << "Robot detected: "
-              << BOLDCYAN << "NAO " << version
-              << RESETCOLOR << std::endl;
+    std::cout << BOLDCYAN << "NAO " << hardware_version << RESETCOLOR;
   }
   if (std::string(robot) == "pepper" || std::string(robot) == "juliette" )
   {
     info.type = naoqi_bridge_msgs::RobotInfo::PEPPER;
-    std::cout << BOLDYELLOW << "Robot detected: "
-              << BOLDCYAN << "Pepper " << version
-              << RESETCOLOR << std::endl;
+    std::cout << BOLDCYAN << "Pepper " << hardware_version << RESETCOLOR;
   }
   if (std::string(robot) == "romeo" )
   {
     info.type = naoqi_bridge_msgs::RobotInfo::ROMEO;
-    std::cout << BOLDYELLOW << "Robot detected: "
-              << BOLDCYAN << "Romeo " << version
-              << RESETCOLOR << std::endl;
+    std::cout << BOLDCYAN << "Romeo " << hardware_version << RESETCOLOR;
   }
+
+  std::cout << BOLDCYAN << " / " << naoqi_version.text << RESETCOLOR << std::endl;
 
   // Get the data from RobotConfig
   qi::AnyObject p_motion = session->service("ALMotion");
@@ -198,6 +197,67 @@ const robot::Robot& getRobot( const qi::SessionPtr& session )
   return robot;
 }
 
+/**
+ * @brief Function that retrieves the NAOqi version of the robot
+ * 
+ * @param session 
+ * @return const robot::NaoqiVersion& 
+ */
+const robot::NaoqiVersion& getNaoqiVersion( const qi::SessionPtr& session )
+{
+  static robot::NaoqiVersion naoqi_version;
+
+  try {
+    qi::AnyObject p_system = session->service("ALSystem");
+    naoqi_version.text = p_system.call<std::string>("systemVersion");
+
+  } catch (const std::exception& e) {
+    std::cerr << "Could not retrieve the version of NAOqi: "
+      << e.what()
+      << std::endl;
+
+    naoqi_version.text = "unknown";
+    return naoqi_version;
+  }
+
+  std::string buff("");
+  std::vector<int> version_numbers;
+
+  for (std::string::size_type i = 0; i < naoqi_version.text.size(); ++i)
+  {
+    if (naoqi_version.text[i] != '.')
+    {
+      buff += naoqi_version.text[i];
+    }
+    else if (naoqi_version.text[i] == '.' && buff != "")
+    {
+      version_numbers.push_back(std::atoi(buff.c_str()));
+      buff = "";
+    }
+  }
+
+  if (buff != "")
+  {
+    version_numbers.push_back(std::atoi(buff.c_str()));
+  }
+
+  if (version_numbers.size() != 4)
+  {
+    std::cerr << "Unconsistent version number for NAOqi, should contain 4 "
+      << "elements: "
+      << naoqi_version.text
+      << std::endl;
+
+    return naoqi_version;
+  }
+
+  naoqi_version.major = version_numbers[0];
+  naoqi_version.minor = version_numbers[1];
+  naoqi_version.patch = version_numbers[2];
+  naoqi_version.build = version_numbers[3];
+  return naoqi_version;
+}
+
 const naoqi_bridge_msgs::RobotInfo& getRobotInfo( const qi::SessionPtr& session )
 {
   static naoqi_bridge_msgs::RobotInfo robot_info =  getRobotInfoLocal(session);
@@ -257,6 +317,47 @@ bool isDepthStereo(const qi::SessionPtr &session) {
    std::cerr << e.what() << std::endl;
    return false;
  }
+}
+
+/**
+ * @brief Function that returns true if the provided naoqi_version is
+ * (strictly) lesser than the specified one (major.minor.patch.build).
+ * 
+ * @param naoqi_version 
+ * @param major 
+ * @param minor 
+ * @param patch 
+ * @param build 
+ * @return true 
+ * @return false 
+ */
+bool isNaoqiVersionLesser(
+  const robot::NaoqiVersion& naoqi_version,
+  const int& major,
+  const int& minor,
+  const int& patch,
+  const int& build)
+{
+  if (naoqi_version.major < major)
+  {
+    return true;
+  }
+  else if (naoqi_version.minor < minor)
+  {
+    return true;
+  }
+  else if (naoqi_version.patch < patch)
+  {
+    return true;
+  }
+  else if (naoqi_version.build < build)
+  {
+    return true;
+  }
+  else
+  {
+    return false;
+  }
 }
 
 } // driver

--- a/src/helpers/driver_helpers.hpp
+++ b/src/helpers/driver_helpers.hpp
@@ -36,6 +36,8 @@ namespace driver
 
 const robot::Robot& getRobot( const qi::SessionPtr& session );
 
+const robot::NaoqiVersion& getNaoqiVersion( const qi::SessionPtr& session );
+
 const naoqi_bridge_msgs::RobotInfo& getRobotInfo( const qi::SessionPtr& session );
 
 bool& setLanguage( const qi::SessionPtr& session, naoqi_bridge_msgs::SetStringRequest req );
@@ -43,6 +45,13 @@ bool& setLanguage( const qi::SessionPtr& session, naoqi_bridge_msgs::SetStringRe
 std::string& getLanguage( const qi::SessionPtr& session );
 
 bool isDepthStereo(const qi::SessionPtr &session);
+
+bool isNaoqiVersionLesser(
+  const robot::NaoqiVersion& naoqi_version,
+  const int& major,
+  const int& minor=0,
+  const int& patch=0,
+  const int& build=0);
 
 } // driver
 } // helpers


### PR DESCRIPTION
Enable the connection of the driver to robots running naoqi 2.9 and greater. When launching the driver, the username and password of the robot can be specified (only required for robots running naoqi 2.9 and greater)
```shell
roslaunch naoqi_driver naoqi_driver.launch nao_ip:=<ip> nao_port:=<port> network_interface:=<interface> username:=<name> password:=<passwd>
```