### PR TITLE
README.md fix typo username -> user

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ required for robots running NAOqi 2.9 or greater.
 
 ```sh
 source <catkin_ws>/devel/setup.bash
-roslaunch naoqi_driver naoqi_driver.launch nao_ip:=<ip> nao_port:=<port> roscore_ip := <ip> network_interface:=<interface> username:=<name> password:=<passwd>
+roslaunch naoqi_driver naoqi_driver.launch nao_ip:=<ip> nao_port:=<port> roscore_ip := <ip> network_interface:=<interface> user:=<name> password:=<passwd>
 ```
 
 Warning: `naoqi_driver` for melodic and greater have to be used for robots


### PR DESCRIPTION
arg of launch file is `user` not `username` https://github.com/ros-naoqi/naoqi_driver/blob/aed1b87e99dda8ce7216841db67ea2fdd38c78a2/launch/naoqi_driver.launch#L8